### PR TITLE
[WIP] feat: 支持高斯数据库以及更多国产库的兼容模式

### DIFF
--- a/doc/sql/snail_job_gauss.sql
+++ b/doc/sql/snail_job_gauss.sql
@@ -1,0 +1,841 @@
+/*
+ 与PG的差异是，唯一约束都写在了 CREATE TABLE 语句内
+ 因为高斯数据库分布式版本在表创建后无法设置非分布列为唯一约束
+ Date: 2025-06-09
+*/
+
+
+-- sj_namespace
+CREATE TABLE sj_namespace
+(
+    id          bigserial PRIMARY KEY,
+    name        varchar(64)  NOT NULL,
+    unique_id   varchar(64)  NOT NULL,
+    description varchar(256) NULL     DEFAULT '',
+    deleted     smallint     NOT NULL DEFAULT 0,
+    create_dt   timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    update_dt   timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uk_sj_namespace_name UNIQUE (name) -- 将唯一索引合并到表创建语句中
+);
+
+COMMENT ON COLUMN sj_namespace.id IS '主键';
+COMMENT ON COLUMN sj_namespace.name IS '名称';
+COMMENT ON COLUMN sj_namespace.unique_id IS '唯一id';
+COMMENT ON COLUMN sj_namespace.description IS '描述';
+COMMENT ON COLUMN sj_namespace.deleted IS '逻辑删除 1、删除';
+COMMENT ON COLUMN sj_namespace.create_dt IS '创建时间';
+COMMENT ON COLUMN sj_namespace.update_dt IS '修改时间';
+COMMENT ON TABLE sj_namespace IS '命名空间';
+
+INSERT INTO sj_namespace (id, name, unique_id, create_dt, update_dt, deleted)
+VALUES (1, 'Default', '764d604ec6fc45f68cd92514c40e9e1a', now(), now(), 0);
+
+-- sj_group_config
+CREATE TABLE sj_group_config
+(
+    id                bigserial PRIMARY KEY,
+    namespace_id      varchar(64)  NOT NULL DEFAULT '764d604ec6fc45f68cd92514c40e9e1a',
+    group_name        varchar(64)  NULL     DEFAULT '',
+    description       varchar(256) NULL     DEFAULT '',
+    token             varchar(64)  NOT NULL DEFAULT 'SJ_cKqBTPzCsWA3VyuCfFoccmuIEGXjr5KT',
+    group_status      smallint     NOT NULL DEFAULT 0,
+    version           int          NOT NULL,
+    group_partition   int          NOT NULL,
+    id_generator_mode smallint     NOT NULL DEFAULT 1,
+    init_scene        smallint     NOT NULL DEFAULT 0,
+    create_dt         timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    update_dt         timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uk_sj_group_config_01 UNIQUE (namespace_id, group_name) -- 将唯一索引合并到表创建语句中
+);
+
+COMMENT ON COLUMN sj_group_config.id IS '主键';
+COMMENT ON COLUMN sj_group_config.namespace_id IS '命名空间id';
+COMMENT ON COLUMN sj_group_config.group_name IS '组名称';
+COMMENT ON COLUMN sj_group_config.description IS '组描述';
+COMMENT ON COLUMN sj_group_config.token IS 'token';
+COMMENT ON COLUMN sj_group_config.group_status IS '组状态 0、未启用 1、启用';
+COMMENT ON COLUMN sj_group_config.version IS '版本号';
+COMMENT ON COLUMN sj_group_config.group_partition IS '分区';
+COMMENT ON COLUMN sj_group_config.id_generator_mode IS '唯一id生成模式 默认号段模式';
+COMMENT ON COLUMN sj_group_config.init_scene IS '是否初始化场景 0:否 1:是';
+COMMENT ON COLUMN sj_group_config.create_dt IS '创建时间';
+COMMENT ON COLUMN sj_group_config.update_dt IS '修改时间';
+COMMENT ON TABLE sj_group_config IS '组配置';
+
+-- sj_notify_config
+CREATE TABLE sj_notify_config
+(
+    id                     bigserial PRIMARY KEY,
+    namespace_id           varchar(64)  NOT NULL DEFAULT '764d604ec6fc45f68cd92514c40e9e1a',
+    group_name             varchar(64)  NOT NULL,
+    notify_name            varchar(64)  NULL     DEFAULT '',
+    system_task_type       smallint     NOT NULL DEFAULT 3,
+    notify_status          smallint     NOT NULL DEFAULT 0,
+    recipient_ids          varchar(128) NOT NULL,
+    notify_threshold       int          NOT NULL DEFAULT 0,
+    notify_scene           smallint     NOT NULL DEFAULT 0,
+    rate_limiter_status    smallint     NOT NULL DEFAULT 0,
+    rate_limiter_threshold int          NOT NULL DEFAULT 0,
+    description            varchar(256) NULL     DEFAULT '',
+    create_dt              timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    update_dt              timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_sj_notify_config_01 ON sj_notify_config (namespace_id, group_name);
+
+COMMENT ON COLUMN sj_notify_config.id IS '主键';
+COMMENT ON COLUMN sj_notify_config.namespace_id IS '命名空间id';
+COMMENT ON COLUMN sj_notify_config.group_name IS '组名称';
+COMMENT ON COLUMN sj_notify_config.notify_name IS '通知名称';
+COMMENT ON COLUMN sj_notify_config.system_task_type IS '任务类型 1. 重试任务 2. 重试回调 3、JOB任务 4、WORKFLOW任务';
+COMMENT ON COLUMN sj_notify_config.notify_status IS '通知状态 0、未启用 1、启用';
+COMMENT ON COLUMN sj_notify_config.recipient_ids IS '接收人id列表';
+COMMENT ON COLUMN sj_notify_config.notify_threshold IS '通知阈值';
+COMMENT ON COLUMN sj_notify_config.notify_scene IS '通知场景';
+COMMENT ON COLUMN sj_notify_config.rate_limiter_status IS '限流状态 0、未启用 1、启用';
+COMMENT ON COLUMN sj_notify_config.rate_limiter_threshold IS '每秒限流阈值';
+COMMENT ON COLUMN sj_notify_config.description IS '描述';
+COMMENT ON COLUMN sj_notify_config.create_dt IS '创建时间';
+COMMENT ON COLUMN sj_notify_config.update_dt IS '修改时间';
+COMMENT ON TABLE sj_notify_config IS '通知配置';
+
+-- sj_notify_recipient
+CREATE TABLE sj_notify_recipient
+(
+    id               bigserial PRIMARY KEY,
+    namespace_id     varchar(64)  NOT NULL DEFAULT '764d604ec6fc45f68cd92514c40e9e1a',
+    recipient_name   varchar(64)  NOT NULL,
+    notify_type      smallint     NOT NULL DEFAULT 0,
+    notify_attribute varchar(512) NOT NULL,
+    description      varchar(256) NULL     DEFAULT '',
+    create_dt        timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    update_dt        timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_sj_notify_recipient_01 ON sj_notify_recipient (namespace_id);
+
+COMMENT ON COLUMN sj_notify_recipient.id IS '主键';
+COMMENT ON COLUMN sj_notify_recipient.namespace_id IS '命名空间id';
+COMMENT ON COLUMN sj_notify_recipient.recipient_name IS '接收人名称';
+COMMENT ON COLUMN sj_notify_recipient.notify_type IS '通知类型 1、钉钉 2、邮件 3、企业微信 4 飞书 5 webhook';
+COMMENT ON COLUMN sj_notify_recipient.notify_attribute IS '配置属性';
+COMMENT ON COLUMN sj_notify_recipient.description IS '描述';
+COMMENT ON COLUMN sj_notify_recipient.create_dt IS '创建时间';
+COMMENT ON COLUMN sj_notify_recipient.update_dt IS '修改时间';
+COMMENT ON TABLE sj_notify_recipient IS '告警通知接收人';
+
+-- sj_retry_dead_letter
+CREATE TABLE sj_retry_dead_letter
+(
+    id            bigserial PRIMARY KEY,
+    namespace_id  varchar(64)  NOT NULL DEFAULT '764d604ec6fc45f68cd92514c40e9e1a',
+    group_name    varchar(64)  NOT NULL,
+    group_id      bigint       NOT NULL,
+    scene_name    varchar(64)  NOT NULL,
+    scene_id      bigint       NOT NULL,
+    idempotent_id varchar(64)  NOT NULL,
+    biz_no        varchar(64)  NULL     DEFAULT '',
+    executor_name varchar(512) NULL     DEFAULT '',
+    args_str      text         NULL,
+    ext_attrs     text         NULL,
+    create_dt     timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_sj_retry_dead_letter_01 ON sj_retry_dead_letter (namespace_id, group_name, scene_name);
+CREATE INDEX idx_sj_retry_dead_letter_02 ON sj_retry_dead_letter (idempotent_id);
+CREATE INDEX idx_sj_retry_dead_letter_03 ON sj_retry_dead_letter (biz_no);
+CREATE INDEX idx_sj_retry_dead_letter_04 ON sj_retry_dead_letter (create_dt);
+
+COMMENT ON COLUMN sj_retry_dead_letter.id IS '主键';
+COMMENT ON COLUMN sj_retry_dead_letter.namespace_id IS '命名空间id';
+COMMENT ON COLUMN sj_retry_dead_letter.group_name IS '组名称';
+COMMENT ON COLUMN sj_retry_dead_letter.group_id IS '组Id';
+COMMENT ON COLUMN sj_retry_dead_letter.scene_name IS '场景名称';
+COMMENT ON COLUMN sj_retry_dead_letter.scene_id IS '场景ID';
+COMMENT ON COLUMN sj_retry_dead_letter.idempotent_id IS '幂等id';
+COMMENT ON COLUMN sj_retry_dead_letter.biz_no IS '业务编号';
+COMMENT ON COLUMN sj_retry_dead_letter.executor_name IS '执行器名称';
+COMMENT ON COLUMN sj_retry_dead_letter.args_str IS '执行方法参数';
+COMMENT ON COLUMN sj_retry_dead_letter.ext_attrs IS '扩展字段';
+COMMENT ON COLUMN sj_retry_dead_letter.create_dt IS '创建时间';
+COMMENT ON TABLE sj_retry_dead_letter IS '死信队列表';
+
+-- sj_retry
+CREATE TABLE sj_retry
+(
+    id              bigserial PRIMARY KEY,
+    namespace_id    varchar(64)  NOT NULL DEFAULT '764d604ec6fc45f68cd92514c40e9e1a',
+    group_name      varchar(64)  NOT NULL,
+    group_id        bigint       NOT NULL,
+    scene_name      varchar(64)  NOT NULL,
+    scene_id        bigint       NOT NULL,
+    idempotent_id   varchar(64)  NOT NULL,
+    biz_no          varchar(64)  NULL     DEFAULT '',
+    executor_name   varchar(512) NULL     DEFAULT '',
+    args_str        text         NULL,
+    ext_attrs       text         NULL,
+    next_trigger_at bigint       NOT NULL,
+    retry_count     int          NOT NULL DEFAULT 0,
+    retry_status    smallint     NOT NULL DEFAULT 0,
+    task_type       smallint     NOT NULL DEFAULT 1,
+    bucket_index    int          NOT NULL DEFAULT 0,
+    parent_id       bigint       NOT NULL DEFAULT 0,
+    deleted         bigint       NOT NULL DEFAULT 0,
+    create_dt       timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    update_dt       timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uk_sj_retry_01 UNIQUE (scene_id, task_type, idempotent_id, deleted) -- 将唯一索引合并到表创建语句中
+);
+
+CREATE INDEX idx_sj_retry_01 ON sj_retry (biz_no);
+CREATE INDEX idx_sj_retry_02 ON sj_retry (retry_status, bucket_index);
+CREATE INDEX idx_sj_retry_03 ON sj_retry (parent_id);
+CREATE INDEX idx_sj_retry_04 ON sj_retry (create_dt);
+CREATE INDEX idx_sj_retry_05 ON sj_retry (idempotent_id);
+
+COMMENT ON COLUMN sj_retry.id IS '主键';
+COMMENT ON COLUMN sj_retry.namespace_id IS '命名空间id';
+COMMENT ON COLUMN sj_retry.group_name IS '组名称';
+COMMENT ON COLUMN sj_retry.group_id IS '组Id';
+COMMENT ON COLUMN sj_retry.scene_name IS '场景名称';
+COMMENT ON COLUMN sj_retry.scene_id IS '场景ID';
+COMMENT ON COLUMN sj_retry.idempotent_id IS '幂等id';
+COMMENT ON COLUMN sj_retry.biz_no IS '业务编号';
+COMMENT ON COLUMN sj_retry.executor_name IS '执行器名称';
+COMMENT ON COLUMN sj_retry.args_str IS '执行方法参数';
+COMMENT ON COLUMN sj_retry.ext_attrs IS '扩展字段';
+COMMENT ON COLUMN sj_retry.next_trigger_at IS '下次触发时间';
+COMMENT ON COLUMN sj_retry.retry_count IS '重试次数';
+COMMENT ON COLUMN sj_retry.retry_status IS '重试状态 0、重试中 1、成功 2、最大重试次数';
+COMMENT ON COLUMN sj_retry.task_type IS '任务类型 1、重试数据 2、回调数据';
+COMMENT ON COLUMN sj_retry.bucket_index IS 'bucket';
+COMMENT ON COLUMN sj_retry.parent_id IS '父节点id';
+COMMENT ON COLUMN sj_retry.deleted IS '逻辑删除';
+COMMENT ON COLUMN sj_retry.create_dt IS '创建时间';
+COMMENT ON COLUMN sj_retry.update_dt IS '修改时间';
+COMMENT ON TABLE sj_retry IS '重试信息表';
+
+-- sj_retry_task
+CREATE TABLE sj_retry_task
+(
+    id               bigserial PRIMARY KEY,
+    namespace_id     varchar(64)  NOT NULL DEFAULT '764d604ec6fc45f68cd92514c40e9e1a',
+    group_name       varchar(64)  NOT NULL,
+    scene_name       varchar(64)  NOT NULL,
+    retry_id         bigint       NOT NULL,
+    ext_attrs        text         NULL,
+    task_status      smallint     NOT NULL DEFAULT 1,
+    task_type        smallint     NOT NULL DEFAULT 1,
+    operation_reason smallint     NOT NULL DEFAULT 0,
+    client_info      varchar(128) NULL     DEFAULT NULL,
+    create_dt        timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    update_dt        timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_sj_retry_task_01 ON sj_retry_task (namespace_id, group_name, scene_name);
+CREATE INDEX idx_sj_retry_task_02 ON sj_retry_task (task_status);
+CREATE INDEX idx_sj_retry_task_03 ON sj_retry_task (create_dt);
+CREATE INDEX idx_sj_retry_task_04 ON sj_retry_task (retry_id);
+
+COMMENT ON COLUMN sj_retry_task.id IS '主键';
+COMMENT ON COLUMN sj_retry_task.namespace_id IS '命名空间id';
+COMMENT ON COLUMN sj_retry_task.group_name IS '组名称';
+COMMENT ON COLUMN sj_retry_task.scene_name IS '场景名称';
+COMMENT ON COLUMN sj_retry_task.retry_id IS '重试信息Id';
+COMMENT ON COLUMN sj_retry_task.ext_attrs IS '扩展字段';
+COMMENT ON COLUMN sj_retry_task.task_status IS '重试状态';
+COMMENT ON COLUMN sj_retry_task.task_type IS '任务类型 1、重试数据 2、回调数据';
+COMMENT ON COLUMN sj_retry_task.operation_reason IS '操作原因';
+COMMENT ON COLUMN sj_retry_task.client_info IS '客户端地址 clientId#ip:port';
+COMMENT ON COLUMN sj_retry_task.create_dt IS '创建时间';
+COMMENT ON COLUMN sj_retry_task.update_dt IS '修改时间';
+COMMENT ON TABLE sj_retry_task IS '重试任务表';
+
+-- sj_retry_task_log_message
+CREATE TABLE sj_retry_task_log_message
+(
+    id            bigserial PRIMARY KEY,
+    namespace_id  varchar(64) NOT NULL DEFAULT '764d604ec6fc45f68cd92514c40e9e1a',
+    group_name    varchar(64) NOT NULL,
+    retry_id      bigint      NOT NULL,
+    retry_task_id bigint      NOT NULL,
+    message       text        NULL,
+    log_num       int         NOT NULL DEFAULT 1,
+    real_time     bigint      NOT NULL DEFAULT 0,
+    create_dt     timestamp   NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_sj_retry_task_log_message_01 ON sj_retry_task_log_message (namespace_id, group_name, retry_task_id);
+CREATE INDEX idx_sj_retry_task_log_message_02 ON sj_retry_task_log_message (create_dt);
+
+COMMENT ON COLUMN sj_retry_task_log_message.id IS '主键';
+COMMENT ON COLUMN sj_retry_task_log_message.namespace_id IS '命名空间id';
+COMMENT ON COLUMN sj_retry_task_log_message.group_name IS '组名称';
+COMMENT ON COLUMN sj_retry_task_log_message.retry_id IS '重试信息Id';
+COMMENT ON COLUMN sj_retry_task_log_message.retry_task_id IS '重试任务Id';
+COMMENT ON COLUMN sj_retry_task_log_message.message IS '异常信息';
+COMMENT ON COLUMN sj_retry_task_log_message.log_num IS '日志数量';
+COMMENT ON COLUMN sj_retry_task_log_message.real_time IS '上报时间';
+COMMENT ON COLUMN sj_retry_task_log_message.create_dt IS '创建时间';
+COMMENT ON TABLE sj_retry_task_log_message IS '任务调度日志信息记录表';
+
+-- sj_retry_scene_config
+CREATE TABLE sj_retry_scene_config
+(
+    id                  bigserial PRIMARY KEY,
+    namespace_id        varchar(64)  NOT NULL DEFAULT '764d604ec6fc45f68cd92514c40e9e1a',
+    scene_name          varchar(64)  NOT NULL,
+    group_name          varchar(64)  NOT NULL,
+    scene_status        smallint     NOT NULL DEFAULT 0,
+    max_retry_count     int          NOT NULL DEFAULT 5,
+    back_off            smallint     NOT NULL DEFAULT 1,
+    trigger_interval    varchar(16)  NULL     DEFAULT '',
+    notify_ids          varchar(128) NULL     DEFAULT '',
+    deadline_request    bigint       NOT NULL DEFAULT 60000,
+    executor_timeout    int          NOT NULL DEFAULT 5,
+    route_key           smallint     NOT NULL DEFAULT 4,
+    block_strategy      smallint     NOT NULL DEFAULT 1,
+    cb_status           smallint     NOT NULL DEFAULT 0,
+    cb_trigger_type     smallint     NOT NULL DEFAULT 1,
+    cb_max_count        int          NOT NULL DEFAULT 16,
+    cb_trigger_interval varchar(16)  NULL     DEFAULT '',
+    description         varchar(256) NULL     DEFAULT '',
+    create_dt           timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    update_dt           timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uk_sj_retry_scene_config_01 UNIQUE (namespace_id, group_name, scene_name)
+);
+
+COMMENT ON COLUMN sj_retry_scene_config.id IS '主键';
+COMMENT ON COLUMN sj_retry_scene_config.namespace_id IS '命名空间id';
+COMMENT ON COLUMN sj_retry_scene_config.scene_name IS '场景名称';
+COMMENT ON COLUMN sj_retry_scene_config.group_name IS '组名称';
+COMMENT ON COLUMN sj_retry_scene_config.scene_status IS '组状态 0、未启用 1、启用';
+COMMENT ON COLUMN sj_retry_scene_config.max_retry_count IS '最大重试次数';
+COMMENT ON COLUMN sj_retry_scene_config.back_off IS '1、默认等级 2、固定间隔时间 3、CRON 表达式';
+COMMENT ON COLUMN sj_retry_scene_config.trigger_interval IS '间隔时长';
+COMMENT ON COLUMN sj_retry_scene_config.notify_ids IS '通知告警场景配置id列表';
+COMMENT ON COLUMN sj_retry_scene_config.deadline_request IS 'Deadline Request 调用链超时 单位毫秒';
+COMMENT ON COLUMN sj_retry_scene_config.executor_timeout IS '任务执行超时时间，单位秒';
+COMMENT ON COLUMN sj_retry_scene_config.route_key IS '路由策略';
+COMMENT ON COLUMN sj_retry_scene_config.block_strategy IS '阻塞策略 1、丢弃 2、覆盖 3、并行';
+COMMENT ON COLUMN sj_retry_scene_config.cb_status IS '回调状态 0、不开启 1、开启';
+COMMENT ON COLUMN sj_retry_scene_config.cb_trigger_type IS '1、默认等级 2、固定间隔时间 3、CRON 表达式';
+COMMENT ON COLUMN sj_retry_scene_config.cb_max_count IS '回调的最大执行次数';
+COMMENT ON COLUMN sj_retry_scene_config.cb_trigger_interval IS '回调的最大执行次数';
+COMMENT ON COLUMN sj_retry_scene_config.description IS '描述';
+COMMENT ON COLUMN sj_retry_scene_config.create_dt IS '创建时间';
+COMMENT ON COLUMN sj_retry_scene_config.update_dt IS '修改时间';
+COMMENT ON TABLE sj_retry_scene_config IS '场景配置';
+
+-- sj_server_node
+CREATE TABLE sj_server_node
+(
+    id           bigserial PRIMARY KEY,
+    namespace_id varchar(64)  NOT NULL DEFAULT '764d604ec6fc45f68cd92514c40e9e1a',
+    group_name   varchar(64)  NOT NULL,
+    host_id      varchar(64)  NOT NULL,
+    host_ip      varchar(64)  NOT NULL,
+    host_port    int          NOT NULL,
+    expire_at    timestamp    NOT NULL,
+    node_type    smallint     NOT NULL,
+    ext_attrs    varchar(256) NULL     DEFAULT '',
+    create_dt    timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    update_dt    timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uk_sj_server_node_01 UNIQUE (host_id, host_ip)
+);
+
+CREATE INDEX idx_sj_server_node_01 ON sj_server_node (namespace_id, group_name);
+CREATE INDEX idx_sj_server_node_02 ON sj_server_node (expire_at, node_type);
+
+COMMENT ON COLUMN sj_server_node.id IS '主键';
+COMMENT ON COLUMN sj_server_node.namespace_id IS '命名空间id';
+COMMENT ON COLUMN sj_server_node.group_name IS '组名称';
+COMMENT ON COLUMN sj_server_node.host_id IS '主机id';
+COMMENT ON COLUMN sj_server_node.host_ip IS '机器ip';
+COMMENT ON COLUMN sj_server_node.host_port IS '机器端口';
+COMMENT ON COLUMN sj_server_node.expire_at IS '过期时间';
+COMMENT ON COLUMN sj_server_node.node_type IS '节点类型 1、客户端 2、是服务端';
+COMMENT ON COLUMN sj_server_node.ext_attrs IS '扩展字段';
+COMMENT ON COLUMN sj_server_node.create_dt IS '创建时间';
+COMMENT ON COLUMN sj_server_node.update_dt IS '修改时间';
+COMMENT ON TABLE sj_server_node IS '服务器节点';
+
+-- sj_distributed_lock
+CREATE TABLE sj_distributed_lock
+(
+    name       varchar(64)  NOT NULL,
+    lock_until timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    locked_at  timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    locked_by  varchar(255) NOT NULL,
+    create_dt  timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    update_dt  timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT pk_sj_distributed_lock PRIMARY KEY (name) -- 假设将 name 设为主键实现唯一约束
+);
+
+COMMENT ON COLUMN sj_distributed_lock.name IS '锁名称';
+COMMENT ON COLUMN sj_distributed_lock.lock_until IS '锁定时长';
+COMMENT ON COLUMN sj_distributed_lock.locked_at IS '锁定时间';
+COMMENT ON COLUMN sj_distributed_lock.locked_by IS '锁定者';
+COMMENT ON COLUMN sj_distributed_lock.create_dt IS '创建时间';
+COMMENT ON COLUMN sj_distributed_lock.update_dt IS '修改时间';
+COMMENT ON TABLE sj_distributed_lock IS '锁定表';
+
+-- sj_system_user
+CREATE TABLE sj_system_user
+(
+    id        bigserial PRIMARY KEY,
+    username  varchar(64)  NOT NULL,
+    password  varchar(128) NOT NULL,
+    role      smallint     NOT NULL DEFAULT 0,
+    create_dt timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    update_dt timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+COMMENT ON COLUMN sj_system_user.id IS '主键';
+COMMENT ON COLUMN sj_system_user.username IS '账号';
+COMMENT ON COLUMN sj_system_user.password IS '密码';
+COMMENT ON COLUMN sj_system_user.role IS '角色：1-普通用户、2-管理员';
+COMMENT ON COLUMN sj_system_user.create_dt IS '创建时间';
+COMMENT ON COLUMN sj_system_user.update_dt IS '修改时间';
+COMMENT ON TABLE sj_system_user IS '系统用户表';
+
+INSERT INTO sj_system_user (username, password, role)
+VALUES ('admin', '465c194afb65670f38322df087f0a9bb225cc257e43eb4ac5a0c98ef5b3173ac', 2);
+
+-- sj_system_user_permission
+CREATE TABLE sj_system_user_permission
+(
+    id             bigserial PRIMARY KEY,
+    group_name     varchar(64) NOT NULL,
+    namespace_id   varchar(64) NOT NULL DEFAULT '764d604ec6fc45f68cd92514c40e9e1a',
+    system_user_id bigint      NOT NULL,
+    create_dt      timestamp   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    update_dt      timestamp   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uk_sj_system_user_permission_01 UNIQUE (namespace_id, group_name, system_user_id)
+);
+
+COMMENT ON COLUMN sj_system_user_permission.id IS '主键';
+COMMENT ON COLUMN sj_system_user_permission.group_name IS '组名称';
+COMMENT ON COLUMN sj_system_user_permission.namespace_id IS '命名空间id';
+COMMENT ON COLUMN sj_system_user_permission.system_user_id IS '系统用户id';
+COMMENT ON COLUMN sj_system_user_permission.create_dt IS '创建时间';
+COMMENT ON COLUMN sj_system_user_permission.update_dt IS '修改时间';
+COMMENT ON TABLE sj_system_user_permission IS '系统用户权限表';
+
+-- sj_sequence_alloc
+CREATE TABLE sj_sequence_alloc
+(
+    id           bigserial PRIMARY KEY,
+    namespace_id varchar(64) NOT NULL DEFAULT '764d604ec6fc45f68cd92514c40e9e1a',
+    group_name   varchar(64) NULL     DEFAULT '',
+    max_id       bigint      NOT NULL DEFAULT 1,
+    step         int         NOT NULL DEFAULT 100,
+    update_dt    timestamp   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uk_sj_sequence_alloc_01 UNIQUE (namespace_id, group_name)
+);
+
+COMMENT ON COLUMN sj_sequence_alloc.id IS '主键';
+COMMENT ON COLUMN sj_sequence_alloc.namespace_id IS '命名空间id';
+COMMENT ON COLUMN sj_sequence_alloc.group_name IS '组名称';
+COMMENT ON COLUMN sj_sequence_alloc.max_id IS '最大id';
+COMMENT ON COLUMN sj_sequence_alloc.step IS '步长';
+COMMENT ON COLUMN sj_sequence_alloc.update_dt IS '更新时间';
+COMMENT ON TABLE sj_sequence_alloc IS '号段模式序号ID分配表';
+
+-- sj_job
+CREATE TABLE sj_job
+(
+    id               bigserial PRIMARY KEY,
+    namespace_id     varchar(64)  NOT NULL DEFAULT '764d604ec6fc45f68cd92514c40e9e1a',
+    group_name       varchar(64)  NOT NULL,
+    job_name         varchar(64)  NOT NULL,
+    args_str         text         NULL     DEFAULT NULL,
+    args_type        smallint     NOT NULL DEFAULT 1,
+    next_trigger_at  bigint       NOT NULL,
+    job_status       smallint     NOT NULL DEFAULT 1,
+    task_type        smallint     NOT NULL DEFAULT 1,
+    route_key        smallint     NOT NULL DEFAULT 4,
+    executor_type    smallint     NOT NULL DEFAULT 1,
+    executor_info    varchar(255) NULL     DEFAULT NULL,
+    trigger_type     smallint     NOT NULL,
+    trigger_interval varchar(255) NOT NULL,
+    block_strategy   smallint     NOT NULL DEFAULT 1,
+    executor_timeout int          NOT NULL DEFAULT 0,
+    max_retry_times  int          NOT NULL DEFAULT 0,
+    parallel_num     int          NOT NULL DEFAULT 1,
+    retry_interval   int          NOT NULL DEFAULT 0,
+    bucket_index     int          NOT NULL DEFAULT 0,
+    resident         smallint     NOT NULL DEFAULT 0,
+    notify_ids       varchar(128) NULL     DEFAULT '',
+    owner_id         bigint       NULL,
+    description      varchar(256) NULL     DEFAULT '',
+    ext_attrs        varchar(256) NULL     DEFAULT '',
+    deleted          smallint     NOT NULL DEFAULT 0,
+    create_dt        timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    update_dt        timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_sj_job_01 ON sj_job (namespace_id, group_name);
+CREATE INDEX idx_sj_job_02 ON sj_job (job_status, bucket_index);
+CREATE INDEX idx_sj_job_03 ON sj_job (create_dt);
+
+COMMENT ON COLUMN sj_job.id IS '主键';
+COMMENT ON COLUMN sj_job.namespace_id IS '命名空间id';
+COMMENT ON COLUMN sj_job.group_name IS '组名称';
+COMMENT ON COLUMN sj_job.job_name IS '名称';
+COMMENT ON COLUMN sj_job.args_str IS '执行方法参数';
+COMMENT ON COLUMN sj_job.args_type IS '参数类型 ';
+COMMENT ON COLUMN sj_job.next_trigger_at IS '下次触发时间';
+COMMENT ON COLUMN sj_job.job_status IS '任务状态 0、关闭、1、开启';
+COMMENT ON COLUMN sj_job.task_type IS '任务类型 1、集群 2、广播 3、切片';
+COMMENT ON COLUMN sj_job.route_key IS '路由策略';
+COMMENT ON COLUMN sj_job.executor_type IS '执行器类型';
+COMMENT ON COLUMN sj_job.executor_info IS '执行器名称';
+COMMENT ON COLUMN sj_job.trigger_type IS '触发类型 1.CRON 表达式 2. 固定时间';
+COMMENT ON COLUMN sj_job.trigger_interval IS '间隔时长';
+COMMENT ON COLUMN sj_job.block_strategy IS '阻塞策略 1、丢弃 2、覆盖 3、并行 4、恢复';
+COMMENT ON COLUMN sj_job.executor_timeout IS '任务执行超时时间，单位秒';
+COMMENT ON COLUMN sj_job.max_retry_times IS '最大重试次数';
+COMMENT ON COLUMN sj_job.parallel_num IS '并行数';
+COMMENT ON COLUMN sj_job.retry_interval IS '重试间隔 ( s)';
+COMMENT ON COLUMN sj_job.bucket_index IS 'bucket';
+COMMENT ON COLUMN sj_job.resident IS '是否是常驻任务';
+COMMENT ON COLUMN sj_job.notify_ids IS '通知告警场景配置id列表';
+COMMENT ON COLUMN sj_job.owner_id IS '负责人id';
+COMMENT ON COLUMN sj_job.description IS '描述';
+COMMENT ON COLUMN sj_job.ext_attrs IS '扩展字段';
+COMMENT ON COLUMN sj_job.deleted IS '逻辑删除 1、删除';
+COMMENT ON COLUMN sj_job.create_dt IS '创建时间';
+COMMENT ON COLUMN sj_job.update_dt IS '修改时间';
+COMMENT ON TABLE sj_job IS '任务信息';
+
+-- sj_job_log_message
+CREATE TABLE sj_job_log_message
+(
+    id            bigserial PRIMARY KEY,
+    namespace_id  varchar(64)  NOT NULL DEFAULT '764d604ec6fc45f68cd92514c40e9e1a',
+    group_name    varchar(64)  NOT NULL,
+    job_id        bigint       NOT NULL,
+    task_batch_id bigint       NOT NULL,
+    task_id       bigint       NOT NULL,
+    message       text         NULL,
+    log_num       int          NOT NULL DEFAULT 1,
+    real_time     bigint       NOT NULL DEFAULT 0,
+    ext_attrs     varchar(256) NULL     DEFAULT '',
+    create_dt     timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_sj_job_log_message_01 ON sj_job_log_message (task_batch_id, task_id);
+CREATE INDEX idx_sj_job_log_message_02 ON sj_job_log_message (create_dt);
+CREATE INDEX idx_sj_job_log_message_03 ON sj_job_log_message (namespace_id, group_name);
+
+COMMENT ON COLUMN sj_job_log_message.id IS '主键';
+COMMENT ON COLUMN sj_job_log_message.namespace_id IS '命名空间id';
+COMMENT ON COLUMN sj_job_log_message.group_name IS '组名称';
+COMMENT ON COLUMN sj_job_log_message.job_id IS '任务信息id';
+COMMENT ON COLUMN sj_job_log_message.task_batch_id IS '任务批次id';
+COMMENT ON COLUMN sj_job_log_message.task_id IS '调度任务id';
+COMMENT ON COLUMN sj_job_log_message.message IS '调度信息';
+COMMENT ON COLUMN sj_job_log_message.log_num IS '日志数量';
+COMMENT ON COLUMN sj_job_log_message.real_time IS '上报时间';
+COMMENT ON COLUMN sj_job_log_message.ext_attrs IS '扩展字段';
+COMMENT ON COLUMN sj_job_log_message.create_dt IS '创建时间';
+COMMENT ON TABLE sj_job_log_message IS '调度日志';
+
+-- sj_job_task
+CREATE TABLE sj_job_task
+(
+    id             bigserial PRIMARY KEY,
+    namespace_id   varchar(64)  NOT NULL DEFAULT '764d604ec6fc45f68cd92514c40e9e1a',
+    group_name     varchar(64)  NOT NULL,
+    job_id         bigint       NOT NULL,
+    task_batch_id  bigint       NOT NULL,
+    parent_id      bigint       NOT NULL DEFAULT 0,
+    task_status    smallint     NOT NULL DEFAULT 0,
+    retry_count    int          NOT NULL DEFAULT 0,
+    mr_stage       smallint     NULL     DEFAULT NULL,
+    leaf           smallint     NOT NULL DEFAULT '1',
+    task_name      varchar(255) NULL     DEFAULT '',
+    client_info    varchar(128) NULL     DEFAULT NULL,
+    wf_context     text         NULL     DEFAULT NULL,
+    result_message text         NULL,
+    args_str       text         NULL     DEFAULT NULL,
+    args_type      smallint     NOT NULL DEFAULT 1,
+    ext_attrs      varchar(256) NULL     DEFAULT '',
+    create_dt      timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    update_dt      timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+
+CREATE INDEX idx_sj_job_task_01 ON sj_job_task (task_batch_id, task_status);
+CREATE INDEX idx_sj_job_task_02 ON sj_job_task (create_dt);
+CREATE INDEX idx_sj_job_task_03 ON sj_job_task (namespace_id, group_name);
+
+COMMENT ON COLUMN sj_job_task.id IS '主键';
+COMMENT ON COLUMN sj_job_task.namespace_id IS '命名空间id';
+COMMENT ON COLUMN sj_job_task.group_name IS '组名称';
+COMMENT ON COLUMN sj_job_task.job_id IS '任务信息id';
+COMMENT ON COLUMN sj_job_task.task_batch_id IS '调度任务id';
+COMMENT ON COLUMN sj_job_task.parent_id IS '父执行器id';
+COMMENT ON COLUMN sj_job_task.task_status IS '执行的状态 0、失败 1、成功';
+COMMENT ON COLUMN sj_job_task.retry_count IS '重试次数';
+COMMENT ON COLUMN sj_job_task.mr_stage IS '动态分片所处阶段 1:map 2:reduce 3:mergeReduce';
+COMMENT ON COLUMN sj_job_task.leaf IS '叶子节点';
+COMMENT ON COLUMN sj_job_task.task_name IS '任务名称';
+COMMENT ON COLUMN sj_job_task.client_info IS '客户端地址 clientId#ip:port';
+COMMENT ON COLUMN sj_job_task.wf_context IS '工作流全局上下文';
+COMMENT ON COLUMN sj_job_task.result_message IS '执行结果';
+COMMENT ON COLUMN sj_job_task.args_str IS '执行方法参数';
+COMMENT ON COLUMN sj_job_task.args_type IS '参数类型 ';
+COMMENT ON COLUMN sj_job_task.ext_attrs IS '扩展字段';
+COMMENT ON COLUMN sj_job_task.create_dt IS '创建时间';
+COMMENT ON COLUMN sj_job_task.update_dt IS '修改时间';
+COMMENT ON TABLE sj_job_task IS '任务实例';
+
+-- sj_job_task_batch
+CREATE TABLE sj_job_task_batch
+(
+    id                      bigserial PRIMARY KEY,
+    namespace_id            varchar(64)  NOT NULL DEFAULT '764d604ec6fc45f68cd92514c40e9e1a',
+    group_name              varchar(64)  NOT NULL,
+    job_id                  bigint       NOT NULL,
+    workflow_node_id        bigint       NOT NULL DEFAULT 0,
+    parent_workflow_node_id bigint       NOT NULL DEFAULT 0,
+    workflow_task_batch_id  bigint       NOT NULL DEFAULT 0,
+    task_batch_status       smallint     NOT NULL DEFAULT 0,
+    operation_reason        smallint     NOT NULL DEFAULT 0,
+    execution_at            bigint       NOT NULL DEFAULT 0,
+    system_task_type        smallint     NOT NULL DEFAULT 3,
+    parent_id               varchar(64)  NULL     DEFAULT '',
+    ext_attrs               varchar(256) NULL     DEFAULT '',
+    deleted                 smallint     NOT NULL DEFAULT 0,
+    create_dt               timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    update_dt               timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT idx_sj_job_task_batch_04 UNIQUE (workflow_task_batch_id, workflow_node_id)
+);
+
+CREATE INDEX idx_sj_job_task_batch_01 ON sj_job_task_batch (job_id, task_batch_status);
+CREATE INDEX idx_sj_job_task_batch_02 ON sj_job_task_batch (create_dt);
+CREATE INDEX idx_sj_job_task_batch_03 ON sj_job_task_batch (namespace_id, group_name);
+
+COMMENT ON COLUMN sj_job_task_batch.id IS '主键';
+COMMENT ON COLUMN sj_job_task_batch.namespace_id IS '命名空间id';
+COMMENT ON COLUMN sj_job_task_batch.group_name IS '组名称';
+COMMENT ON COLUMN sj_job_task_batch.job_id IS '任务id';
+COMMENT ON COLUMN sj_job_task_batch.workflow_node_id IS '工作流节点id';
+COMMENT ON COLUMN sj_job_task_batch.parent_workflow_node_id IS '工作流任务父批次id';
+COMMENT ON COLUMN sj_job_task_batch.workflow_task_batch_id IS '工作流任务批次id';
+COMMENT ON COLUMN sj_job_task_batch.task_batch_status IS '任务批次状态 0、失败 1、成功';
+COMMENT ON COLUMN sj_job_task_batch.operation_reason IS '操作原因';
+COMMENT ON COLUMN sj_job_task_batch.execution_at IS '任务执行时间';
+COMMENT ON COLUMN sj_job_task_batch.system_task_type IS '任务类型 3、JOB任务 4、WORKFLOW任务';
+COMMENT ON COLUMN sj_job_task_batch.parent_id IS '父节点';
+COMMENT ON COLUMN sj_job_task_batch.ext_attrs IS '扩展字段';
+COMMENT ON COLUMN sj_job_task_batch.deleted IS '逻辑删除 1、删除';
+COMMENT ON COLUMN sj_job_task_batch.create_dt IS '创建时间';
+COMMENT ON COLUMN sj_job_task_batch.update_dt IS '修改时间';
+COMMENT ON TABLE sj_job_task_batch IS '任务批次';
+
+-- sj_job_summary
+CREATE TABLE sj_job_summary
+(
+    id               bigserial PRIMARY KEY,
+    namespace_id     varchar(64)  NOT NULL DEFAULT '764d604ec6fc45f68cd92514c40e9e1a',
+    group_name       varchar(64)  NULL     DEFAULT '',
+    business_id      bigint       NOT NULL,
+    system_task_type smallint     NOT NULL DEFAULT 3,
+    trigger_at       timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    success_num      int          NOT NULL DEFAULT 0,
+    fail_num         int          NOT NULL DEFAULT 0,
+    fail_reason      varchar(512) NULL     DEFAULT '',
+    stop_num         int          NOT NULL DEFAULT 0,
+    stop_reason      varchar(512) NULL     DEFAULT '',
+    cancel_num       int          NOT NULL DEFAULT 0,
+    cancel_reason    varchar(512) NULL     DEFAULT '',
+    create_dt        timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    update_dt        timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uk_sj_job_summary_01 UNIQUE (trigger_at, system_task_type, business_id)
+);
+
+CREATE INDEX idx_sj_job_summary_01 ON sj_job_summary (namespace_id, group_name, business_id);
+
+COMMENT ON COLUMN sj_job_summary.id IS '主键';
+COMMENT ON COLUMN sj_job_summary.namespace_id IS '命名空间id';
+COMMENT ON COLUMN sj_job_summary.group_name IS '组名称';
+COMMENT ON COLUMN sj_job_summary.business_id IS '业务id  ( job_id或workflow_id)';
+COMMENT ON COLUMN sj_job_summary.system_task_type IS '任务类型 3、JOB任务 4、WORKFLOW任务';
+COMMENT ON COLUMN sj_job_summary.trigger_at IS '统计时间';
+COMMENT ON COLUMN sj_job_summary.success_num IS '执行成功-日志数量';
+COMMENT ON COLUMN sj_job_summary.fail_num IS '执行失败-日志数量';
+COMMENT ON COLUMN sj_job_summary.fail_reason IS '失败原因';
+COMMENT ON COLUMN sj_job_summary.stop_num IS '执行失败-日志数量';
+COMMENT ON COLUMN sj_job_summary.stop_reason IS '失败原因';
+COMMENT ON COLUMN sj_job_summary.cancel_num IS '执行失败-日志数量';
+COMMENT ON COLUMN sj_job_summary.cancel_reason IS '失败原因';
+COMMENT ON COLUMN sj_job_summary.create_dt IS '创建时间';
+COMMENT ON COLUMN sj_job_summary.update_dt IS '修改时间';
+COMMENT ON TABLE sj_job_summary IS 'DashBoard_Job';
+
+-- sj_retry_summary
+CREATE TABLE sj_retry_summary
+(
+    id            bigserial PRIMARY KEY,
+    namespace_id  varchar(64) NOT NULL DEFAULT '764d604ec6fc45f68cd92514c40e9e1a',
+    group_name    varchar(64) NULL     DEFAULT '',
+    scene_name    varchar(50) NULL     DEFAULT '',
+    trigger_at    timestamp   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    running_num   int         NOT NULL DEFAULT 0,
+    finish_num    int         NOT NULL DEFAULT 0,
+    max_count_num int         NOT NULL DEFAULT 0,
+    suspend_num   int         NOT NULL DEFAULT 0,
+    create_dt     timestamp   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    update_dt     timestamp   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uk_sj_retry_summary_01 UNIQUE (namespace_id, group_name, scene_name, trigger_at)
+);
+
+CREATE INDEX idx_sj_retry_summary_01 ON sj_retry_summary (trigger_at);
+
+COMMENT ON COLUMN sj_retry_summary.id IS '主键';
+COMMENT ON COLUMN sj_retry_summary.namespace_id IS '命名空间id';
+COMMENT ON COLUMN sj_retry_summary.group_name IS '组名称';
+COMMENT ON COLUMN sj_retry_summary.scene_name IS '场景名称';
+COMMENT ON COLUMN sj_retry_summary.trigger_at IS '统计时间';
+COMMENT ON COLUMN sj_retry_summary.running_num IS '重试中-日志数量';
+COMMENT ON COLUMN sj_retry_summary.finish_num IS '重试完成-日志数量';
+COMMENT ON COLUMN sj_retry_summary.max_count_num IS '重试到达最大次数-日志数量';
+COMMENT ON COLUMN sj_retry_summary.suspend_num IS '暂停重试-日志数量';
+COMMENT ON COLUMN sj_retry_summary.create_dt IS '创建时间';
+COMMENT ON COLUMN sj_retry_summary.update_dt IS '修改时间';
+COMMENT ON TABLE sj_retry_summary IS 'DashBoard_Retry';
+
+-- sj_workflow
+CREATE TABLE sj_workflow
+(
+    id               bigserial PRIMARY KEY,
+    workflow_name    varchar(64)  NOT NULL,
+    namespace_id     varchar(64)  NOT NULL DEFAULT '764d604ec6fc45f68cd92514c40e9e1a',
+    group_name       varchar(64)  NOT NULL,
+    workflow_status  smallint     NOT NULL DEFAULT 1,
+    trigger_type     smallint     NOT NULL,
+    trigger_interval varchar(255) NOT NULL,
+    next_trigger_at  bigint       NOT NULL,
+    block_strategy   smallint     NOT NULL DEFAULT 1,
+    executor_timeout int          NOT NULL DEFAULT 0,
+    description      varchar(256) NULL     DEFAULT '',
+    flow_info        text         NULL     DEFAULT NULL,
+    wf_context       text         NULL     DEFAULT NULL,
+    notify_ids       varchar(128) NULL     DEFAULT '',
+    bucket_index     int          NOT NULL DEFAULT 0,
+    version          int          NOT NULL,
+    ext_attrs        varchar(256) NULL     DEFAULT '',
+    deleted          smallint     NOT NULL DEFAULT 0,
+    create_dt        timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    update_dt        timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_sj_workflow_01 ON sj_workflow (create_dt);
+CREATE INDEX idx_sj_workflow_02 ON sj_workflow (namespace_id, group_name);
+
+COMMENT ON COLUMN sj_workflow.id IS '主键';
+COMMENT ON COLUMN sj_workflow.workflow_name IS '工作流名称';
+COMMENT ON COLUMN sj_workflow.namespace_id IS '命名空间id';
+COMMENT ON COLUMN sj_workflow.group_name IS '组名称';
+COMMENT ON COLUMN sj_workflow.workflow_status IS '工作流状态 0、关闭、1、开启';
+COMMENT ON COLUMN sj_workflow.trigger_type IS '触发类型 1.CRON 表达式 2. 固定时间';
+COMMENT ON COLUMN sj_workflow.trigger_interval IS '间隔时长';
+COMMENT ON COLUMN sj_workflow.next_trigger_at IS '下次触发时间';
+COMMENT ON COLUMN sj_workflow.block_strategy IS '阻塞策略 1、丢弃 2、覆盖 3、并行';
+COMMENT ON COLUMN sj_workflow.executor_timeout IS '任务执行超时时间，单位秒';
+COMMENT ON COLUMN sj_workflow.description IS '描述';
+COMMENT ON COLUMN sj_workflow.flow_info IS '流程信息';
+COMMENT ON COLUMN sj_workflow.wf_context IS '上下文';
+COMMENT ON COLUMN sj_workflow.notify_ids IS '通知告警场景配置id列表';
+COMMENT ON COLUMN sj_workflow.bucket_index IS 'bucket';
+COMMENT ON COLUMN sj_workflow.version IS '版本号';
+COMMENT ON COLUMN sj_workflow.ext_attrs IS '扩展字段';
+COMMENT ON COLUMN sj_workflow.deleted IS '逻辑删除 1、删除';
+COMMENT ON COLUMN sj_workflow.create_dt IS '创建时间';
+COMMENT ON COLUMN sj_workflow.update_dt IS '修改时间';
+COMMENT ON TABLE sj_workflow IS '工作流';
+
+-- sj_workflow_node
+CREATE TABLE sj_workflow_node
+(
+    id                   bigserial PRIMARY KEY,
+    namespace_id         varchar(64)  NOT NULL DEFAULT '764d604ec6fc45f68cd92514c40e9e1a',
+    node_name            varchar(64)  NOT NULL,
+    group_name           varchar(64)  NOT NULL,
+    job_id               bigint       NOT NULL,
+    workflow_id          bigint       NOT NULL,
+    node_type            smallint     NOT NULL DEFAULT 1,
+    expression_type      smallint     NOT NULL DEFAULT 0,
+    fail_strategy        smallint     NOT NULL DEFAULT 1,
+    workflow_node_status smallint     NOT NULL DEFAULT 1,
+    priority_level       int          NOT NULL DEFAULT 1,
+    node_info            text         NULL     DEFAULT NULL,
+    version              int          NOT NULL,
+    ext_attrs            varchar(256) NULL     DEFAULT '',
+    deleted              smallint     NOT NULL DEFAULT 0,
+    create_dt            timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    update_dt            timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_sj_workflow_node_01 ON sj_workflow_node (create_dt);
+CREATE INDEX idx_sj_workflow_node_02 ON sj_workflow_node (namespace_id, group_name);
+
+COMMENT ON COLUMN sj_workflow_node.id IS '主键';
+COMMENT ON COLUMN sj_workflow_node.namespace_id IS '命名空间id';
+COMMENT ON COLUMN sj_workflow_node.node_name IS '节点名称';
+COMMENT ON COLUMN sj_workflow_node.group_name IS '组名称';
+COMMENT ON COLUMN sj_workflow_node.job_id IS '任务信息id';
+COMMENT ON COLUMN sj_workflow_node.workflow_id IS '工作流ID';
+COMMENT ON COLUMN sj_workflow_node.node_type IS '1、任务节点 2、条件节点';
+COMMENT ON COLUMN sj_workflow_node.expression_type IS '1、SpEl、2、Aviator 3、QL';
+COMMENT ON COLUMN sj_workflow_node.fail_strategy IS '失败策略 1、跳过 2、阻塞';
+COMMENT ON COLUMN sj_workflow_node.workflow_node_status IS '工作流节点状态 0、关闭、1、开启';
+COMMENT ON COLUMN sj_workflow_node.priority_level IS '优先级';
+COMMENT ON COLUMN sj_workflow_node.node_info IS '节点信息 ';
+COMMENT ON COLUMN sj_workflow_node.version IS '版本号';
+COMMENT ON COLUMN sj_workflow_node.ext_attrs IS '扩展字段';
+COMMENT ON COLUMN sj_workflow_node.deleted IS '逻辑删除 1、删除';
+COMMENT ON COLUMN sj_workflow_node.create_dt IS '创建时间';
+COMMENT ON COLUMN sj_workflow_node.update_dt IS '修改时间';
+COMMENT ON TABLE sj_workflow_node IS '工作流节点';
+
+-- sj_workflow_task_batch
+CREATE TABLE sj_workflow_task_batch
+(
+    id                bigserial PRIMARY KEY,
+    namespace_id      varchar(64)  NOT NULL DEFAULT '764d604ec6fc45f68cd92514c40e9e1a',
+    group_name        varchar(64)  NOT NULL,
+    workflow_id       bigint       NOT NULL,
+    task_batch_status smallint     NOT NULL DEFAULT 0,
+    operation_reason  smallint     NOT NULL DEFAULT 0,
+    flow_info         text         NULL     DEFAULT NULL,
+    wf_context        text         NULL     DEFAULT NULL,
+    execution_at      bigint       NOT NULL DEFAULT 0,
+    ext_attrs         varchar(256) NULL     DEFAULT '',
+    version           int          NOT NULL DEFAULT 1,
+    deleted           smallint     NOT NULL DEFAULT 0,
+    create_dt         timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    update_dt         timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_sj_workflow_task_batch_01 ON sj_workflow_task_batch (workflow_id, task_batch_status);
+CREATE INDEX idx_sj_workflow_task_batch_02 ON sj_workflow_task_batch (create_dt);
+CREATE INDEX idx_sj_workflow_task_batch_03 ON sj_workflow_task_batch (namespace_id, group_name);
+
+COMMENT ON COLUMN sj_workflow_task_batch.id IS '主键';
+COMMENT ON COLUMN sj_workflow_task_batch.namespace_id IS '命名空间id';
+COMMENT ON COLUMN sj_workflow_task_batch.group_name IS '组名称';
+COMMENT ON COLUMN sj_workflow_task_batch.workflow_id IS '工作流任务id';
+COMMENT ON COLUMN sj_workflow_task_batch.task_batch_status IS '任务批次状态 0、失败 1、成功';
+COMMENT ON COLUMN sj_workflow_task_batch.operation_reason IS '操作原因';
+COMMENT ON COLUMN sj_workflow_task_batch.flow_info IS '流程信息';
+COMMENT ON COLUMN sj_workflow_task_batch.wf_context IS '全局上下文';
+COMMENT ON COLUMN sj_workflow_task_batch.execution_at IS '任务执行时间';
+COMMENT ON COLUMN sj_workflow_task_batch.ext_attrs IS '扩展字段';
+COMMENT ON COLUMN sj_workflow_task_batch.version IS '版本号';
+COMMENT ON COLUMN sj_workflow_task_batch.deleted IS '逻辑删除 1、删除';
+COMMENT ON COLUMN sj_workflow_task_batch.create_dt IS '创建时间';
+COMMENT ON COLUMN sj_workflow_task_batch.update_dt IS '修改时间';
+COMMENT ON TABLE sj_workflow_task_batch IS '工作流批次';

--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,11 @@
                 <artifactId>snail-job-kingbase-datasource</artifactId>
                 <version>${revision}</version>
             </dependency>
+            <dependency>
+                <groupId>com.aizuda</groupId>
+                <artifactId>snail-job-gauss-datasource</artifactId>
+                <version>${revision}</version>
+            </dependency>
 
             <!--      SnailJob client      -->
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <netty-all.version>4.1.119.Final</netty-all.version>
         <hutool.version>5.8.32</hutool.version>
         <mybatis-spring.version>3.0.3</mybatis-spring.version>
-        <mybatis-plus.version>3.5.9</mybatis-plus.version>
+        <mybatis-plus.version>3.5.12</mybatis-plus.version>
         <tinylog.version>1.3.6</tinylog.version>
         <tinylog2.version>2.6.2</tinylog2.version>
         <logtube.version>0.45.0</logtube.version>

--- a/snail-job-common/snail-job-common-core/src/main/java/com/aizuda/snailjob/common/core/model/LongToStringModule.java
+++ b/snail-job-common/snail-job-common-core/src/main/java/com/aizuda/snailjob/common/core/model/LongToStringModule.java
@@ -1,0 +1,30 @@
+package com.aizuda.snailjob.common.core.model;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import java.io.IOException;
+
+/**
+ * @author fangzhengjin
+ * @date 2025-06-09 16:08
+ */
+public class LongToStringModule extends SimpleModule {
+    public LongToStringModule() {
+        super("LongToStringModule");
+        this.addSerializer(Long.class, new JsonSerializer<>() {
+            @Override
+            public void serialize(Long value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+                gen.writeString(value.toString());
+            }
+        });
+        this.addSerializer(Long.TYPE, new JsonSerializer<>() {
+            @Override
+            public void serialize(Long value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+                gen.writeString(value.toString());
+            }
+        });
+    }
+}

--- a/snail-job-common/snail-job-common-core/src/main/java/com/aizuda/snailjob/common/core/util/JsonUtil.java
+++ b/snail-job-common/snail-job-common-core/src/main/java/com/aizuda/snailjob/common/core/util/JsonUtil.java
@@ -2,6 +2,7 @@ package com.aizuda.snailjob.common.core.util;
 
 import cn.hutool.core.util.StrUtil;
 import com.aizuda.snailjob.common.core.exception.SnailJobCommonException;
+import com.aizuda.snailjob.common.core.model.LongToStringModule;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
@@ -242,6 +243,7 @@ public class JsonUtil {
 
             // 注册JAVA 时间序列化器
             objectMapper.registerModule(javaTimeModule);
+            objectMapper.registerModule(new LongToStringModule());
             return objectMapper;
         }
 

--- a/snail-job-datasource/pom.xml
+++ b/snail-job-datasource/pom.xml
@@ -21,6 +21,7 @@
         <module>snail-job-oracle-datasource</module>
         <module>snail-job-sqlserver-datasource</module>
         <module>snail-job-dm8-datasource</module>
+        <module>snail-job-gauss-datasource</module>
         <module>snail-job-kingbase-datasource</module>
         <module>snail-job-datasource-template</module>
     </modules>

--- a/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/access/config/AbstractConfigAccess.java
+++ b/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/access/config/AbstractConfigAccess.java
@@ -43,15 +43,6 @@ public abstract class AbstractConfigAccess<T> implements ConfigAccess<T> {
     @Autowired
     protected NotifyRecipientMapper notifyRecipientMapper;
 
-    protected static final List<String> ALLOW_DB = Arrays.asList(
-            DbTypeEnum.MYSQL.getDb(),
-            DbTypeEnum.MARIADB.getDb(),
-            DbTypeEnum.POSTGRES.getDb(),
-            DbTypeEnum.ORACLE.getDb(),
-            DbTypeEnum.SQLSERVER.getDb(),
-            DbTypeEnum.DM.getDb(),
-            DbTypeEnum.KINGBASE.getDb());
-
     protected DbTypeEnum getDbType() {
         return DbUtils.getDbType();
     }

--- a/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/access/config/GroupConfigAccess.java
+++ b/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/access/config/GroupConfigAccess.java
@@ -22,7 +22,7 @@ public class GroupConfigAccess extends AbstractConfigAccess<GroupConfig> {
     public boolean supports(String operationType) {
         DbTypeEnum dbType = getDbType();
         return OperationTypeEnum.GROUP.name().equals(operationType)
-                && ALLOW_DB.contains(dbType.getDb());
+                && dbType.isAllowDb();
     }
 
     @Override

--- a/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/access/config/NotifyConfigAccess.java
+++ b/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/access/config/NotifyConfigAccess.java
@@ -22,7 +22,7 @@ public class NotifyConfigAccess extends AbstractConfigAccess<NotifyConfig> {
     public boolean supports(String operationType) {
         DbTypeEnum dbType = getDbType();
         return OperationTypeEnum.NOTIFY.name().equals(operationType)
-                && ALLOW_DB.contains(dbType.getDb());
+                && dbType.isAllowDb();
     }
 
     @Override

--- a/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/access/config/SceneConfigAccess.java
+++ b/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/access/config/SceneConfigAccess.java
@@ -22,7 +22,7 @@ public class SceneConfigAccess extends AbstractConfigAccess<RetrySceneConfig> {
     public boolean supports(String operationType) {
         DbTypeEnum dbType = getDbType();
         return OperationTypeEnum.SCENE.name().equals(operationType)
-                && ALLOW_DB.contains(dbType.getDb());
+                && dbType.isAllowDb();
     }
 
     @Override

--- a/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/access/log/RetryTaskLogMessageAccess.java
+++ b/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/access/log/RetryTaskLogMessageAccess.java
@@ -35,7 +35,7 @@ public class RetryTaskLogMessageAccess implements RetryLogAccess<RetryTaskLogMes
 
     @Override
     public boolean supports(String operationType) {
-        return DbTypeEnum.all().contains(getDbType()) && OperationTypeEnum.RETRY_LOG.name().equals(operationType);
+        return getDbType().isAllowDb() && OperationTypeEnum.RETRY_LOG.name().equals(operationType);
 
     }
     @Override

--- a/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/access/task/AbstractTaskAccess.java
+++ b/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/access/task/AbstractTaskAccess.java
@@ -16,15 +16,6 @@ import java.util.List;
  */
 public abstract class AbstractTaskAccess<T> implements TaskAccess<T> {
 
-    protected static final List<String> ALLOW_DB = Arrays.asList(
-            DbTypeEnum.MYSQL.getDb(),
-            DbTypeEnum.MARIADB.getDb(),
-            DbTypeEnum.POSTGRES.getDb(),
-            DbTypeEnum.ORACLE.getDb(),
-            DbTypeEnum.SQLSERVER.getDb(),
-            DbTypeEnum.DM.getDb(),
-            DbTypeEnum.KINGBASE.getDb());
-
     protected DbTypeEnum getDbType() {
         return DbUtils.getDbType();
     }

--- a/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/access/task/RetryAccess.java
+++ b/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/access/task/RetryAccess.java
@@ -29,7 +29,7 @@ public class RetryAccess extends AbstractTaskAccess<Retry> {
     public boolean supports(String operationType) {
         DbTypeEnum dbType = getDbType();
         return OperationTypeEnum.RETRY.name().equals(operationType)
-                && ALLOW_DB.contains(dbType.getDb());
+                && dbType.isAllowDb();
     }
 
     @Override

--- a/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/access/task/RetryDeadLetterTaskAccess.java
+++ b/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/access/task/RetryDeadLetterTaskAccess.java
@@ -27,7 +27,7 @@ public class RetryDeadLetterTaskAccess extends AbstractTaskAccess<RetryDeadLette
     public boolean supports(String operationType) {
         DbTypeEnum dbType = getDbType();
         return OperationTypeEnum.RETRY_DEAD_LETTER.name().equals(operationType)
-                && ALLOW_DB.contains(dbType.getDb());
+                && dbType.isAllowDb();
     }
 
     @Override

--- a/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/access/task/RetryTaskAccess.java
+++ b/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/access/task/RetryTaskAccess.java
@@ -29,7 +29,7 @@ public class RetryTaskAccess extends AbstractTaskAccess<Retry> {
     public boolean supports(String operationType) {
         DbTypeEnum dbType = getDbType();
         return OperationTypeEnum.RETRY_TASK.name().equals(operationType)
-                && ALLOW_DB.contains(dbType.getDb());
+                && dbType.isAllowDb();
     }
 
     @Override

--- a/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/config/SnailJobTemplateAutoConfiguration.java
+++ b/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/config/SnailJobTemplateAutoConfiguration.java
@@ -45,7 +45,15 @@ public class SnailJobTemplateAutoConfiguration {
 
         // 动态设置mapper资源: 通用 + 数据库专用
         PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
-        Resource[] specificMapperResource = resolver.getResources(MessageFormat.format("classpath*:/{0}/mapper/*.xml", dbTypeEnum.getDb()));
+        String dbCompatibilityType = dbTypeEnum.getName();
+        if (dbTypeEnum.mysqlSameType()) {
+            dbCompatibilityType = "mysql";
+        } else if (dbTypeEnum.oracleSameType()) {
+            dbCompatibilityType = "oracle";
+        } else if (dbTypeEnum.postgresqlSameType()) {
+            dbCompatibilityType = "postgresql";
+        }
+        Resource[] specificMapperResource = resolver.getResources(MessageFormat.format("classpath*:/{0}/mapper/*.xml", dbCompatibilityType));
         Resource[] templateMapperResource = resolver.getResources("classpath*:/template/mapper/*.xml");
         List<Resource> resources = new ArrayList<>();
         resources.addAll(List.of(specificMapperResource));

--- a/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/enums/DbTypeEnum.java
+++ b/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/enums/DbTypeEnum.java
@@ -1,9 +1,8 @@
 package com.aizuda.snailjob.template.datasource.enums;
 
-import com.aizuda.snailjob.template.datasource.exception.SnailJobDatasourceException;
-import com.baomidou.mybatisplus.annotation.DbType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.util.StringUtils;
 
 import java.util.Arrays;
 import java.util.List;
@@ -18,30 +17,312 @@ import java.util.List;
 @AllArgsConstructor
 @Getter
 public enum DbTypeEnum {
-    MYSQL("mysql", "MySql database", DbType.MYSQL),
-    MARIADB("mariadb", "MariaDB database", DbType.MARIADB),
-    POSTGRES("postgresql", "Postgres database", DbType.POSTGRE_SQL),
-    ORACLE("oracle", "Oracle database", DbType.ORACLE_12C),
-    SQLSERVER("sqlserver", "SQL Server database", DbType.SQL_SERVER),
-    DM("dm", "Dameng database", DbType.DM),
-    KINGBASE("kingbase", "Renmin University of China Golden Warehouse", DbType.KINGBASE_ES);
 
-    private final String db;
-    private final String desc;
-    @Deprecated(since = "1.2.0-beta1")
-    private final DbType mpDbType;
+    /**
+     * ClickHouse
+     */
+    CLICK_HOUSE("clickhouse", "clickhouse 数据库"),
 
-    public static DbTypeEnum modeOf(String db) {
-        for (DbTypeEnum value : DbTypeEnum.values()) {
-            if (db.contains(value.getDb())) {
-                return value;
-            }
+    /**
+     * CSIIDB
+     */
+    CSIIDB("csiidb", "CSIIDB 数据库"),
+
+    /**
+     * CUBRID
+     */
+    CUBRID("cubrid", "CUBRID 数据库"),
+
+    /**
+     * DB2
+     */
+    DB2("db2", "DB2 数据库"),
+    DB2_1005("db2_1005", "DB2 10.5版本数据库"),
+
+    /**
+     * derby
+     */
+    DERBY("derby", "Derby 数据库"),
+
+    /**
+     * DM
+     */
+    DM("dm", "达梦数据库"),
+
+    /**
+     * Doris 兼容 Mysql，使用 MySql 驱动和协议
+     */
+    DORIS("doris", "doris 数据库"),
+
+    /**
+     * Duckdb
+     */
+    DUCKDB("duckdb", "duckdb 数据库"),
+
+    /**
+     * Firebird
+     */
+    FIREBIRD("Firebird", "Firebird 数据库"),
+
+    /**
+     * Gauss
+     */
+    GAUSS("gauss", "Gauss 数据库"),
+
+    /**
+     * GBase
+     */
+    GBASE("gbase", "南大通用(华库)数据库"),
+
+    /**
+     * GBase-8c
+     */
+    GBASE_8C("gbase-8c", "南大通用数据库 GBase 8c"),
+
+    /**
+     * GBase-8s
+     */
+    GBASE_8S("gbase-8s", "南大通用数据库 GBase 8s"),
+
+    /**
+     * GBase-8s-pg
+     */
+    GBASE_8S_PG("gbase-8s-pg", "南大通用数据库 GBase 8s兼容pg"),
+
+    /**
+     * GOLDENDB
+     */
+    GOLDENDB("goldendb", "GoldenDB数据库"),
+
+    /**
+     * GOLDILOCKS
+     */
+    GOLDILOCKS("goldilocks", "GOLDILOCKS 数据库"),
+
+    /**
+     * greenplum
+     */
+    GREENPLUM("greenplum", "greenplum 数据库"),
+
+    /**
+     * H2
+     */
+    H2("h2", "H2 数据库"),
+
+    /**
+     * HighGo
+     */
+    HIGH_GO("highgo", "瀚高数据库"),
+
+    /**
+     * Hive SQL
+     */
+    HIVE("Hive", "Hive SQL"),
+
+    /**
+     * HSQL
+     */
+    HSQL("hsql", "HSQL 数据库"),
+
+    /**
+     * Impala
+     */
+    IMPALA("impala", "impala 数据库"),
+
+    /**
+     * Informix
+     */
+    INFORMIX("informix", "Informix 数据库"),
+
+    /**
+     * Kingbase
+     */
+    KINGBASE_ES("kingbasees", "人大金仓数据库"),
+
+    /**
+     * lealone
+     */
+    LEALONE("lealone", "lealone 数据库"),
+
+    /**
+     * MARIADB
+     */
+    MARIADB("mariadb", "MariaDB 数据库"),
+
+    /**
+     * MYSQL
+     */
+    MYSQL("mysql", "MySql 数据库"),
+
+    /**
+     * OceanBase
+     */
+    OCEAN_BASE("oceanbase", "OceanBase 数据库"),
+
+    /**
+     * openGauss
+     */
+    OPENGAUSS("openGauss", "华为 openGauss 数据库"),
+
+    /**
+     * ORACLE
+     */
+    ORACLE("oracle", "Oracle11g 及以下数据库"),
+
+    /**
+     * oracle12c
+     */
+    ORACLE_12C("oracle12c", "Oracle12c 及以上数据库"),
+
+    /**
+     * Oscar
+     */
+    OSCAR("oscar", "神通数据库"),
+
+    /**
+     * Phoenix
+     */
+    PHOENIX("phoenix", "Phoenix HBase 数据库"),
+
+    /**
+     * POSTGRE_SQL
+     */
+    POSTGRE_SQL("postgresql", "PostgreSQL 数据库"),
+
+    /**
+     * presto
+     */
+    PRESTO("presto", "Presto数据库"),
+
+    /**
+     * redshift
+     */
+    REDSHIFT("redshift", "亚马逊 redshift 数据库"),
+
+    /**
+     * SAP_HANA
+     */
+    SAP_HANA("hana", "SAP_HANA 数据库"),
+
+    /**
+     * sinodb
+     */
+    SINODB("sinodb", "SinoDB 数据库"),
+
+    /**
+     * SQLITE
+     */
+    SQLITE("sqlite", "SQLite 数据库"),
+
+    /**
+     * SQLSERVER
+     */
+    SQLSERVER("sqlserver", "SQLServer 数据库"),
+
+    /**
+     * SqlServer 2005 数据库
+     */
+    SQLSERVER_2005("sqlserver_2005", "SQLServer 数据库"),
+
+    /**
+     * SUNDB
+     */
+    SUNDB("sundb", "SUNDB数据库"),
+
+    /**
+     * Sybase
+     */
+    SYBASE("sybase", "Sybase ASE 数据库"),
+
+    /**
+     * TDengine
+     */
+    TDENGINE("TDengine", "TDengine 数据库"),
+
+    /**
+     * Trino
+     */
+    TRINO("trino", "trino 数据库"),
+
+    /**
+     * uxdb
+     */
+    UXDB("uxdb", "优炫数据库"),
+
+    /**
+     * VASTBASE
+     */
+    VASTBASE("vastbase", "Vastbase数据库"),
+
+    /**
+     * Vertica
+     */
+    VERTICA("vertica", "vertica数据库"),
+
+    /**
+     * XCloud
+     */
+    XCloud("xcloud", "行云数据库"),
+
+    /**
+     * xugu
+     */
+    XUGU("xugu", "虚谷数据库"),
+
+    /**
+     * yasdb
+     */
+    YASDB("yasdb", "崖山数据库"),
+
+    /**
+     * OTHER
+     */
+    OTHER("other", "其他数据库");
+
+    /**
+     * 数据库名称
+     */
+    private final String name;
+
+    /**
+     * 描述
+     */
+    private final String remarks;
+
+    /**
+     * 根据数据库类型名称自动识别数据库类型
+     *
+     * @param name 名称
+     * @return 数据库类型
+     */
+    public static DbTypeEnum findByName(String name) {
+        if (!StringUtils.hasText(name)) {
+            return null;
         }
 
-        throw new SnailJobDatasourceException("This database is not supported yet [{}]", db);
+        return Arrays.stream(values())
+                .filter(em -> em.getName().equalsIgnoreCase(name))
+                .findFirst()
+                .orElse(null);
     }
 
     public static List<DbTypeEnum> all() {
         return Arrays.asList(DbTypeEnum.values());
+    }
+
+    public boolean mysqlSameType() {
+        return this == MYSQL || this == MARIADB || this == GBASE || this == OSCAR || this == XUGU || this == CLICK_HOUSE || this == OCEAN_BASE || this == CUBRID || this == SUNDB || this == GOLDENDB || this == YASDB;
+    }
+
+    public boolean oracleSameType() {
+        return this == ORACLE || this == DM || this == GAUSS;
+    }
+
+    public boolean postgresqlSameType() {
+        return this == POSTGRE_SQL || this == H2 || this == LEALONE || this == SQLITE || this == HSQL || this == KINGBASE_ES || this == PHOENIX || this == SAP_HANA || this == IMPALA || this == HIGH_GO || this == VERTICA || this == REDSHIFT || this == OPENGAUSS || this == TDENGINE || this == UXDB || this == GBASE_8S_PG || this == GBASE_8C || this == VASTBASE || this == DUCKDB;
+    }
+
+    public boolean isAllowDb() {
+        return mysqlSameType() || oracleSameType() || postgresqlSameType();
     }
 }

--- a/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/enums/DbTypeEnum.java
+++ b/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/enums/DbTypeEnum.java
@@ -315,11 +315,11 @@ public enum DbTypeEnum {
     }
 
     public boolean oracleSameType() {
-        return this == ORACLE || this == DM || this == GAUSS;
+        return this == ORACLE || this == DM;
     }
 
     public boolean postgresqlSameType() {
-        return this == POSTGRE_SQL || this == H2 || this == LEALONE || this == SQLITE || this == HSQL || this == KINGBASE_ES || this == PHOENIX || this == SAP_HANA || this == IMPALA || this == HIGH_GO || this == VERTICA || this == REDSHIFT || this == OPENGAUSS || this == TDENGINE || this == UXDB || this == GBASE_8S_PG || this == GBASE_8C || this == VASTBASE || this == DUCKDB;
+        return this == POSTGRE_SQL || this == H2 || this == LEALONE || this == SQLITE || this == HSQL || this == KINGBASE_ES || this == PHOENIX || this == SAP_HANA || this == IMPALA || this == HIGH_GO || this == VERTICA || this == REDSHIFT || this == GAUSS || this == OPENGAUSS || this == TDENGINE || this == UXDB || this == GBASE_8S_PG || this == GBASE_8C || this == VASTBASE || this == DUCKDB;
     }
 
     public boolean isAllowDb() {

--- a/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/DistributedLock.java
+++ b/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/DistributedLock.java
@@ -1,6 +1,5 @@
 package com.aizuda.snailjob.template.datasource.persistence.po;
 
-import com.baomidou.mybatisplus.annotation.IdType;
 import com.baomidou.mybatisplus.annotation.TableId;
 import com.baomidou.mybatisplus.annotation.TableName;
 import lombok.Data;

--- a/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/GroupConfig.java
+++ b/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/GroupConfig.java
@@ -1,6 +1,5 @@
 package com.aizuda.snailjob.template.datasource.persistence.po;
 
-import com.baomidou.mybatisplus.annotation.IdType;
 import com.baomidou.mybatisplus.annotation.TableField;
 import com.baomidou.mybatisplus.annotation.TableId;
 import com.baomidou.mybatisplus.annotation.TableName;
@@ -18,7 +17,7 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode(callSuper=true)
 public class GroupConfig extends CreateUpdateDt {
 
-    @TableId(value = "id", type = IdType.AUTO)
+    @TableId(value = "id")
     private Long id;
 
     private String namespaceId;

--- a/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/Job.java
+++ b/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/Job.java
@@ -22,7 +22,7 @@ public class Job extends CreateUpdateDt {
     /**
      * 主键
      */
-    @TableId(value = "id", type = IdType.AUTO)
+    @TableId(value = "id")
     private Long id;
 
     /**

--- a/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/JobLogMessage.java
+++ b/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/JobLogMessage.java
@@ -1,6 +1,5 @@
 package com.aizuda.snailjob.template.datasource.persistence.po;
 
-import com.baomidou.mybatisplus.annotation.IdType;
 import com.baomidou.mybatisplus.annotation.TableId;
 import com.baomidou.mybatisplus.annotation.TableName;
 import lombok.Data;
@@ -20,7 +19,7 @@ public class JobLogMessage extends CreateDt {
     /**
      * 主键
      */
-    @TableId(value = "id", type = IdType.AUTO)
+    @TableId(value = "id")
     private Long id;
 
     /**

--- a/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/JobNotifyConfig.java
+++ b/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/JobNotifyConfig.java
@@ -1,6 +1,5 @@
 package com.aizuda.snailjob.template.datasource.persistence.po;
 
-import com.baomidou.mybatisplus.annotation.IdType;
 import com.baomidou.mybatisplus.annotation.TableId;
 import com.baomidou.mybatisplus.annotation.TableName;
 import lombok.Data;
@@ -17,7 +16,7 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode(callSuper=true)
 public class JobNotifyConfig extends CreateUpdateDt {
 
-    @TableId(value = "id", type = IdType.AUTO)
+    @TableId(value = "id")
     private Long id;
 
     private String namespaceId;

--- a/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/JobSummary.java
+++ b/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/JobSummary.java
@@ -1,6 +1,5 @@
 package com.aizuda.snailjob.template.datasource.persistence.po;
 
-import com.baomidou.mybatisplus.annotation.IdType;
 import com.baomidou.mybatisplus.annotation.TableId;
 import com.baomidou.mybatisplus.annotation.TableName;
 import lombok.Data;
@@ -33,7 +32,7 @@ public class JobSummary extends CreateUpdateDt {
     /**
      * 主键
      */
-    @TableId(value = "id", type = IdType.AUTO)
+    @TableId(value = "id")
     private Long id;
 
     /**

--- a/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/JobTask.java
+++ b/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/JobTask.java
@@ -4,7 +4,6 @@ import com.aizuda.snailjob.common.core.enums.JobArgsTypeEnum;
 import com.aizuda.snailjob.common.core.enums.JobTaskStatusEnum;
 import com.aizuda.snailjob.common.core.enums.MapReduceStageEnum;
 import com.aizuda.snailjob.common.core.enums.StatusEnum;
-import com.baomidou.mybatisplus.annotation.IdType;
 import com.baomidou.mybatisplus.annotation.TableField;
 import com.baomidou.mybatisplus.annotation.TableId;
 import com.baomidou.mybatisplus.annotation.TableName;
@@ -25,7 +24,7 @@ public class JobTask extends CreateUpdateDt {
     /**
      * 主键
      */
-    @TableId(value = "id", type = IdType.AUTO)
+    @TableId(value = "id")
     private Long id;
 
     /**

--- a/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/JobTaskBatch.java
+++ b/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/JobTaskBatch.java
@@ -1,6 +1,5 @@
 package com.aizuda.snailjob.template.datasource.persistence.po;
 
-import com.baomidou.mybatisplus.annotation.IdType;
 import com.baomidou.mybatisplus.annotation.TableId;
 import com.baomidou.mybatisplus.annotation.TableName;
 import lombok.Data;
@@ -21,7 +20,7 @@ public class JobTaskBatch extends CreateUpdateDt {
     /**
      * 主键
      */
-    @TableId(value = "id", type = IdType.AUTO)
+    @TableId(value = "id")
     private Long id;
 
     /**

--- a/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/Namespace.java
+++ b/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/Namespace.java
@@ -1,6 +1,5 @@
 package com.aizuda.snailjob.template.datasource.persistence.po;
 
-import com.baomidou.mybatisplus.annotation.IdType;
 import com.baomidou.mybatisplus.annotation.TableId;
 import com.baomidou.mybatisplus.annotation.TableName;
 import lombok.Data;
@@ -20,7 +19,7 @@ public class Namespace extends CreateUpdateDt {
     /**
      * 主键
      */
-    @TableId(value = "id", type = IdType.AUTO)
+    @TableId(value = "id")
     private Long id;
 
     /**

--- a/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/NotifyConfig.java
+++ b/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/NotifyConfig.java
@@ -1,6 +1,5 @@
 package com.aizuda.snailjob.template.datasource.persistence.po;
 
-import com.baomidou.mybatisplus.annotation.IdType;
 import com.baomidou.mybatisplus.annotation.TableId;
 import com.baomidou.mybatisplus.annotation.TableName;
 import lombok.Data;
@@ -13,7 +12,7 @@ import java.time.LocalDateTime;
 @EqualsAndHashCode(callSuper=true)
 public class NotifyConfig extends CreateUpdateDt {
 
-    @TableId(value = "id", type = IdType.AUTO)
+    @TableId(value = "id")
     private Long id;
 
     private String namespaceId;

--- a/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/NotifyRecipient.java
+++ b/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/NotifyRecipient.java
@@ -1,6 +1,5 @@
 package com.aizuda.snailjob.template.datasource.persistence.po;
 
-import com.baomidou.mybatisplus.annotation.IdType;
 import com.baomidou.mybatisplus.annotation.TableId;
 import com.baomidou.mybatisplus.annotation.TableName;
 import lombok.Getter;
@@ -20,7 +19,7 @@ public class NotifyRecipient extends CreateUpdateDt {
     /**
      * 主键
      */
-    @TableId(value = "id", type = IdType.AUTO)
+    @TableId(value = "id")
     private Long id;
 
     /**

--- a/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/Retry.java
+++ b/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/Retry.java
@@ -1,6 +1,5 @@
 package com.aizuda.snailjob.template.datasource.persistence.po;
 
-import com.baomidou.mybatisplus.annotation.IdType;
 import com.baomidou.mybatisplus.annotation.TableId;
 import com.baomidou.mybatisplus.annotation.TableName;
 import lombok.Data;
@@ -16,7 +15,7 @@ import java.time.LocalDateTime;
 @TableName("sj_retry")
 public class Retry extends CreateUpdateDt {
 
-    @TableId(value = "id", type = IdType.AUTO)
+    @TableId(value = "id")
     private Long id;
 
     private String namespaceId;

--- a/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/RetryDeadLetter.java
+++ b/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/RetryDeadLetter.java
@@ -1,6 +1,5 @@
 package com.aizuda.snailjob.template.datasource.persistence.po;
 
-import com.baomidou.mybatisplus.annotation.IdType;
 import com.baomidou.mybatisplus.annotation.TableId;
 import com.baomidou.mybatisplus.annotation.TableName;
 import lombok.Data;
@@ -14,7 +13,7 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode(callSuper=true)
 public class RetryDeadLetter extends CreateDt {
 
-    @TableId(value = "id", type = IdType.AUTO)
+    @TableId(value = "id")
     private Long id;
 
     private String namespaceId;

--- a/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/RetrySceneConfig.java
+++ b/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/RetrySceneConfig.java
@@ -1,6 +1,5 @@
 package com.aizuda.snailjob.template.datasource.persistence.po;
 
-import com.baomidou.mybatisplus.annotation.IdType;
 import com.baomidou.mybatisplus.annotation.TableId;
 import com.baomidou.mybatisplus.annotation.TableName;
 import lombok.Data;
@@ -18,7 +17,7 @@ import lombok.EqualsAndHashCode;
 @TableName("sj_retry_scene_config")
 public class RetrySceneConfig extends CreateUpdateDt {
 
-    @TableId(value = "id", type = IdType.AUTO)
+    @TableId(value = "id")
     private Long id;
 
     private String namespaceId;

--- a/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/RetrySummary.java
+++ b/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/RetrySummary.java
@@ -1,6 +1,5 @@
 package com.aizuda.snailjob.template.datasource.persistence.po;
 
-import com.baomidou.mybatisplus.annotation.IdType;
 import com.baomidou.mybatisplus.annotation.TableId;
 import com.baomidou.mybatisplus.annotation.TableName;
 import lombok.Data;
@@ -21,7 +20,7 @@ public class RetrySummary extends CreateUpdateDt {
     /**
      * 主键
      */
-    @TableId(value = "id", type = IdType.AUTO)
+    @TableId(value = "id")
     private Long id;
 
     /**

--- a/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/RetryTask.java
+++ b/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/RetryTask.java
@@ -1,6 +1,5 @@
 package com.aizuda.snailjob.template.datasource.persistence.po;
 
-import com.baomidou.mybatisplus.annotation.IdType;
 import com.baomidou.mybatisplus.annotation.TableId;
 import com.baomidou.mybatisplus.annotation.TableName;
 import lombok.Data;
@@ -18,7 +17,7 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode(callSuper=true)
 public class RetryTask extends CreateUpdateDt {
 
-    @TableId(value = "id", type = IdType.AUTO)
+    @TableId(value = "id")
     private Long id;
 
     private String namespaceId;

--- a/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/RetryTaskLogMessage.java
+++ b/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/RetryTaskLogMessage.java
@@ -1,6 +1,5 @@
 package com.aizuda.snailjob.template.datasource.persistence.po;
 
-import com.baomidou.mybatisplus.annotation.IdType;
 import com.baomidou.mybatisplus.annotation.TableId;
 import com.baomidou.mybatisplus.annotation.TableName;
 import lombok.Data;
@@ -20,7 +19,7 @@ public class RetryTaskLogMessage extends CreateDt {
     /**
      * 主键
      */
-    @TableId(value = "id", type = IdType.AUTO)
+    @TableId(value = "id")
     private Long id;
 
     /**

--- a/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/SequenceAlloc.java
+++ b/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/SequenceAlloc.java
@@ -22,7 +22,7 @@ public class SequenceAlloc implements Serializable {
     /**
      * 主键
      */
-    @TableId(value = "id", type = IdType.AUTO)
+    @TableId(value = "id")
     private Long id;
 
     /**

--- a/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/ServerNode.java
+++ b/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/ServerNode.java
@@ -1,6 +1,5 @@
 package com.aizuda.snailjob.template.datasource.persistence.po;
 
-import com.baomidou.mybatisplus.annotation.IdType;
 import com.baomidou.mybatisplus.annotation.TableId;
 import com.baomidou.mybatisplus.annotation.TableName;
 import lombok.Data;
@@ -19,7 +18,7 @@ import java.time.LocalDateTime;
 @EqualsAndHashCode(callSuper=true)
 public class ServerNode extends CreateUpdateDt {
 
-    @TableId(value = "id", type = IdType.AUTO)
+    @TableId(value = "id")
     private Long id;
 
     private String namespaceId;

--- a/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/SystemUser.java
+++ b/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/SystemUser.java
@@ -1,6 +1,5 @@
 package com.aizuda.snailjob.template.datasource.persistence.po;
 
-import com.baomidou.mybatisplus.annotation.IdType;
 import com.baomidou.mybatisplus.annotation.TableId;
 import com.baomidou.mybatisplus.annotation.TableName;
 import lombok.Data;
@@ -17,7 +16,7 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode(callSuper=true)
 public class SystemUser extends CreateUpdateDt {
 
-    @TableId(value = "id", type = IdType.AUTO)
+    @TableId(value = "id")
     private Long id;
 
     private String username;

--- a/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/SystemUserPermission.java
+++ b/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/SystemUserPermission.java
@@ -1,6 +1,5 @@
 package com.aizuda.snailjob.template.datasource.persistence.po;
 
-import com.baomidou.mybatisplus.annotation.IdType;
 import com.baomidou.mybatisplus.annotation.TableId;
 import com.baomidou.mybatisplus.annotation.TableName;
 import lombok.Data;
@@ -17,7 +16,7 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode(callSuper=true)
 public class SystemUserPermission extends CreateDt {
 
-    @TableId(value = "id", type = IdType.AUTO)
+    @TableId(value = "id")
     private Long id;
 
     private String groupName;

--- a/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/Workflow.java
+++ b/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/Workflow.java
@@ -1,6 +1,5 @@
 package com.aizuda.snailjob.template.datasource.persistence.po;
 
-import com.baomidou.mybatisplus.annotation.IdType;
 import com.baomidou.mybatisplus.annotation.TableField;
 import com.baomidou.mybatisplus.annotation.TableId;
 import com.baomidou.mybatisplus.annotation.TableName;
@@ -23,7 +22,7 @@ public class Workflow extends CreateUpdateDt {
     /**
      * 主键
      */
-    @TableId(value = "id", type = IdType.AUTO)
+    @TableId(value = "id")
     private Long id;
 
     /**

--- a/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/WorkflowNode.java
+++ b/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/WorkflowNode.java
@@ -1,6 +1,5 @@
 package com.aizuda.snailjob.template.datasource.persistence.po;
 
-import com.baomidou.mybatisplus.annotation.IdType;
 import com.baomidou.mybatisplus.annotation.TableId;
 import com.baomidou.mybatisplus.annotation.TableName;
 import lombok.Data;
@@ -20,7 +19,7 @@ public class WorkflowNode extends CreateUpdateDt {
     /**
      * 主键
      */
-    @TableId(value = "id", type = IdType.AUTO)
+    @TableId(value = "id")
     private Long id;
 
     /**

--- a/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/WorkflowTaskBatch.java
+++ b/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/persistence/po/WorkflowTaskBatch.java
@@ -1,6 +1,5 @@
 package com.aizuda.snailjob.template.datasource.persistence.po;
 
-import com.baomidou.mybatisplus.annotation.IdType;
 import com.baomidou.mybatisplus.annotation.TableField;
 import com.baomidou.mybatisplus.annotation.TableId;
 import com.baomidou.mybatisplus.annotation.TableName;
@@ -25,7 +24,7 @@ public class WorkflowTaskBatch extends CreateUpdateDt {
     /**
      * 主键
      */
-    @TableId(value = "id", type = IdType.AUTO)
+    @TableId(value = "id")
     private Long id;
 
     /**

--- a/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/utils/DbUtils.java
+++ b/snail-job-datasource/snail-job-datasource-template/src/main/java/com/aizuda/snailjob/template/datasource/utils/DbUtils.java
@@ -2,7 +2,14 @@ package com.aizuda.snailjob.template.datasource.utils;
 
 import com.aizuda.snailjob.common.core.context.SnailSpringContext;
 import com.aizuda.snailjob.template.datasource.enums.DbTypeEnum;
-import org.springframework.core.env.Environment;
+import com.aizuda.snailjob.template.datasource.exception.SnailJobDatasourceException;
+import org.apache.ibatis.datasource.unpooled.UnpooledDataSource;
+import org.springframework.util.StringUtils;
+
+import javax.sql.DataSource;
+import java.lang.reflect.Method;
+import java.sql.Connection;
+import java.util.regex.Pattern;
 
 /**
  * 数据库工具
@@ -12,17 +19,176 @@ import org.springframework.core.env.Environment;
  */
 public class DbUtils {
 
+    private static DbTypeEnum DEFAULT_DB_TYPE_ENUM = null;
+
     public static DbTypeEnum getDbType() {
-        Environment environment = SnailSpringContext.getBean(Environment.class);
-        String url = environment.getProperty("spring.datasource.url");
-        return DbTypeEnum.modeOf(url);
+        if (DEFAULT_DB_TYPE_ENUM == null) {
+            DataSource dataSource = SnailSpringContext.getBean(DataSource.class);
+            DEFAULT_DB_TYPE_ENUM = getDbType(dataSource);
+        }
+        return DEFAULT_DB_TYPE_ENUM;
     }
 
-    public static boolean isOracle() {
-        return DbTypeEnum.ORACLE.equals(getDbType());
+    /**
+     * 获取当前配置的 DbType
+     */
+    public static DbTypeEnum getDbType(DataSource dataSource) {
+        String jdbcUrl = getJdbcUrl(dataSource);
+        if (StringUtils.hasText(jdbcUrl)) {
+            return parseDbType(jdbcUrl);
+        }
+
+        throw new IllegalStateException("Can not get dataSource jdbcUrl: " + dataSource.getClass().getName());
     }
 
-    public static boolean notOracle() {
-        return !DbTypeEnum.ORACLE.equals(getDbType());
+    /**
+     * 通过数据源中获取 jdbc 的 url 配置
+     * 符合 HikariCP, druid, c3p0, DBCP, beecp 数据源框架 以及 MyBatis UnpooledDataSource 的获取规则
+     * UnpooledDataSource 参考 @{@link UnpooledDataSource#getUrl()}
+     *
+     * @return jdbc url 配置
+     */
+    public static String getJdbcUrl(DataSource dataSource) {
+        String[] methodNames = new String[]{"getUrl", "getJdbcUrl"};
+        for (String methodName : methodNames) {
+            try {
+                Method method = dataSource.getClass().getMethod(methodName);
+                return (String) method.invoke(dataSource);
+            } catch (Exception e) {
+                //ignore
+            }
+        }
+
+        try (Connection connection = dataSource.getConnection()) {
+            return connection.getMetaData().getURL();
+        } catch (Exception e) {
+            throw new SnailJobDatasourceException("Can not get the dataSource jdbcUrl.");
+        }
+    }
+
+
+    /**
+     * 参考 druid  和 MyBatis-plus 的 JdbcUtils
+     * {@link com.alibaba.druid.util.JdbcUtils#getDbType(String, String)}
+     * {@link com.baomidou.mybatisplus.extension.toolkit.JdbcUtils#getDbType(String)}
+     *
+     * @param jdbcUrl jdbcURL
+     * @return 返回数据库类型
+     */
+    public static DbTypeEnum parseDbType(String jdbcUrl) {
+        jdbcUrl = jdbcUrl.toLowerCase();
+        if (jdbcUrl.contains(":ch:") || jdbcUrl.contains(":clickhouse:")) {
+            return DbTypeEnum.CLICK_HOUSE;
+        } else if (jdbcUrl.contains(":cobar:")) {
+            return DbTypeEnum.MYSQL;
+        } else if (jdbcUrl.contains(":csiidb:")) {
+            return DbTypeEnum.CSIIDB;
+        } else if (jdbcUrl.contains(":cubrid:")) {
+            return DbTypeEnum.CUBRID;
+        } else if (jdbcUrl.contains(":db2:")) {
+            return DbTypeEnum.DB2;
+        } else if (jdbcUrl.contains(":derby:")) {
+            return DbTypeEnum.DERBY;
+        } else if (isMatchedRegex(":dm\\d*:", jdbcUrl)) {
+            return DbTypeEnum.DM;
+        } else if (jdbcUrl.contains(":duckdb:")) {
+            return DbTypeEnum.DUCKDB;
+        } else if (jdbcUrl.contains(":firebirdsql:")) {
+            return DbTypeEnum.FIREBIRD;
+        } else if (jdbcUrl.contains(":gaussdb:") || jdbcUrl.contains(":zenith:")) {
+            return DbTypeEnum.GAUSS;
+        } else if (jdbcUrl.contains(":gbase:")) {
+            return DbTypeEnum.GBASE;
+        } else if (jdbcUrl.contains(":gbase8c:")) {
+            return DbTypeEnum.GBASE_8C;
+        } else if (jdbcUrl.contains(":gbase8s-pg:")) {
+            return DbTypeEnum.GBASE_8S_PG;
+        } else if (jdbcUrl.contains(":gbasedbt-sqli:") || jdbcUrl.contains(":informix-sqli:")) {
+            return DbTypeEnum.GBASE_8S;
+        } else if (jdbcUrl.contains(":goldendb:")) {
+            return DbTypeEnum.GOLDENDB;
+        } else if (jdbcUrl.contains(":goldilocks:")) {
+            return DbTypeEnum.GOLDILOCKS;
+        } else if (jdbcUrl.contains(":greenplum:")) {
+            return DbTypeEnum.GREENPLUM;
+        } else if (jdbcUrl.contains(":h2:")) {
+            return DbTypeEnum.H2;
+        } else if (jdbcUrl.contains(":highgo:")) {
+            return DbTypeEnum.HIGH_GO;
+        } else if (jdbcUrl.contains(":hive2:") || jdbcUrl.contains(":inceptor2:")) {
+            return DbTypeEnum.HIVE;
+        } else if (jdbcUrl.contains(":hsqldb:")) {
+            return DbTypeEnum.HSQL;
+        } else if (jdbcUrl.contains(":impala:")) {
+            return DbTypeEnum.IMPALA;
+        } else if (jdbcUrl.contains(":informix")) {
+            return DbTypeEnum.INFORMIX;
+        } else if (jdbcUrl.contains(":kingbase\\d*:") && isMatchedRegex(":kingbase\\d*:", jdbcUrl)) {
+            return DbTypeEnum.KINGBASE_ES;
+        } else if (jdbcUrl.contains(":lealone:")) {
+            return DbTypeEnum.LEALONE;
+        } else if (jdbcUrl.contains(":mariadb:")) {
+            return DbTypeEnum.MARIADB;
+        } else if (jdbcUrl.contains(":mysql:")) {
+            return DbTypeEnum.MYSQL;
+        } else if (jdbcUrl.contains(":oceanbase:")) {
+            return DbTypeEnum.OCEAN_BASE;
+        } else if (jdbcUrl.contains(":opengauss:")) {
+            return DbTypeEnum.OPENGAUSS;
+        } else if (jdbcUrl.contains(":oracle:")) {
+            return DbTypeEnum.ORACLE;
+        } else if (jdbcUrl.contains(":oscar:")) {
+            return DbTypeEnum.OSCAR;
+        } else if (jdbcUrl.contains(":phoenix:")) {
+            return DbTypeEnum.PHOENIX;
+        } else if (jdbcUrl.contains(":postgresql:")) {
+            return DbTypeEnum.POSTGRE_SQL;
+        } else if (jdbcUrl.contains(":presto:")) {
+            return DbTypeEnum.PRESTO;
+        } else if (jdbcUrl.contains(":redshift:")) {
+            return DbTypeEnum.REDSHIFT;
+        } else if (jdbcUrl.contains(":sap:")) {
+            return DbTypeEnum.SAP_HANA;
+        } else if (jdbcUrl.contains(":sinodb")) {
+            return DbTypeEnum.SINODB;
+        } else if (jdbcUrl.contains(":sqlite:")) {
+            return DbTypeEnum.SQLITE;
+        } else if (jdbcUrl.contains(":sqlserver:")) {
+            return DbTypeEnum.SQLSERVER_2005;
+        } else if (jdbcUrl.contains(":sqlserver2012:")) {
+            return DbTypeEnum.SQLSERVER;
+        } else if (jdbcUrl.contains(":sundb:")) {
+            return DbTypeEnum.SUNDB;
+        } else if (jdbcUrl.contains(":sybase:")) {
+            return DbTypeEnum.SYBASE;
+        } else if (jdbcUrl.contains(":taos:") || jdbcUrl.contains(":taos-rs:")) {
+            return DbTypeEnum.TDENGINE;
+        } else if (jdbcUrl.contains(":trino:")) {
+            return DbTypeEnum.TRINO;
+        } else if (jdbcUrl.contains(":uxdb:")) {
+            return DbTypeEnum.UXDB;
+        } else if (jdbcUrl.contains(":vastbase:")) {
+            return DbTypeEnum.VASTBASE;
+        } else if (jdbcUrl.contains(":vertica:")) {
+            return DbTypeEnum.VERTICA;
+        } else if (jdbcUrl.contains(":xcloud:")) {
+            return DbTypeEnum.XCloud;
+        } else if (jdbcUrl.contains(":xugu:")) {
+            return DbTypeEnum.XUGU;
+        } else if (jdbcUrl.contains(":yasdb:")) {
+            return DbTypeEnum.YASDB;
+        } else {
+            return DbTypeEnum.OTHER;
+        }
+    }
+
+    /**
+     * 正则匹配，验证成功返回 true，验证失败返回 false
+     */
+    public static boolean isMatchedRegex(String regex, String jdbcUrl) {
+        if (null == jdbcUrl) {
+            return false;
+        }
+        return Pattern.compile(regex).matcher(jdbcUrl).find();
     }
 }

--- a/snail-job-datasource/snail-job-gauss-datasource/pom.xml
+++ b/snail-job-datasource/snail-job-gauss-datasource/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.aizuda</groupId>
+        <artifactId>snail-job-datasource</artifactId>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>snail-job-gauss-datasource</artifactId>
+    <name>snail-job-gauss-datasource</name>
+    <description>snail-job-gauss-datasource</description>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <!--    preprocessor    -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- 中央仓库只有最新版本的数据库驱动，而且不同server版本的驱动可能有差异，需要用户自行引入 -->
+
+        <dependency>
+            <groupId>com.aizuda</groupId>
+            <artifactId>snail-job-datasource-template</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>none</mainClass>     <!-- 取消查找本项目下的Main方法：为了解决Unable to find main class的问题 -->
+                    <classifier>execute</classifier>    <!-- 为了解决依赖模块找不到此模块中的类或属性 -->
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/snail-job-datasource/snail-job-gauss-datasource/src/main/resources/gauss/mapper/JobLogMessageMapper.xml
+++ b/snail-job-datasource/snail-job-gauss-datasource/src/main/resources/gauss/mapper/JobLogMessageMapper.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.aizuda.snailjob.template.datasource.persistence.mapper.JobLogMessageMapper">
+
+    <insert id="insertBatch" parameterType="java.util.List">
+        INSERT INTO sj_job_log_message (namespace_id, group_name, job_id, task_batch_id, task_id,
+                                        log_num, message, create_dt, real_time)
+        VALUES
+            <foreach collection="list" item="item" separator=",">
+                (
+                    #{item.namespaceId},
+                    #{item.groupName},
+                    #{item.jobId},
+                    #{item.taskBatchId},
+                    #{item.taskId},
+                    #{item.logNum},
+                    #{item.message},
+                    #{item.createDt},
+                    #{item.realTime}
+                )
+            </foreach>
+    </insert>
+
+</mapper>

--- a/snail-job-datasource/snail-job-gauss-datasource/src/main/resources/gauss/mapper/JobMapper.xml
+++ b/snail-job-datasource/snail-job-gauss-datasource/src/main/resources/gauss/mapper/JobMapper.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.aizuda.snailjob.template.datasource.persistence.mapper.JobMapper">
+
+    <update id="updateBatchNextTriggerAtById" parameterType="java.util.List">
+        UPDATE sj_job AS rt
+           SET next_trigger_at = tt.next_trigger_at,
+               update_dt = CURRENT_TIMESTAMP
+          FROM (
+                <foreach collection="list" item="item" index="index" separator="UNION ALL">
+                    SELECT
+                        #{item.id}              AS id,
+                        #{item.nextTriggerAt}   AS next_trigger_at
+                </foreach>
+               ) AS tt
+         WHERE rt.id = tt.id
+    </update>
+
+</mapper>

--- a/snail-job-datasource/snail-job-gauss-datasource/src/main/resources/gauss/mapper/JobSummaryMapper.xml
+++ b/snail-job-datasource/snail-job-gauss-datasource/src/main/resources/gauss/mapper/JobSummaryMapper.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.aizuda.snailjob.template.datasource.persistence.mapper.JobSummaryMapper">
+
+    <insert id="insertBatch" parameterType="java.util.List">
+        INSERT INTO sj_job_summary (namespace_id, group_name, business_id, trigger_at, system_task_type, success_num,
+                                    fail_num, fail_reason, stop_num, stop_reason, cancel_num, cancel_reason)
+        VALUES
+            <foreach collection="list" item="item" separator=",">
+                (
+                    #{item.namespaceId},
+                    #{item.groupName},
+                    #{item.businessId},
+                    #{item.triggerAt},
+                    #{item.systemTaskType},
+                    #{item.successNum},
+                    #{item.failNum},
+                    #{item.failReason},
+                    #{item.stopNum},
+                    #{item.stopReason},
+                    #{item.cancelNum},
+                    #{item.cancelReason}
+                )
+            </foreach>
+    </insert>
+
+    <update id="updateBatch" parameterType="java.util.List">
+        UPDATE sj_job_summary AS rt
+           SET success_num = tt.success_num,
+               fail_num = tt.fail_num,
+               fail_reason = tt.fail_reason,
+               stop_num = tt.stop_num,
+               stop_reason = tt.stop_reason,
+               cancel_num = tt.cancel_num,
+               cancel_reason = tt.cancel_reason,
+               update_dt = CURRENT_TIMESTAMP
+          FROM (
+                <foreach collection="list" item="item" index="index" separator="UNION ALL">
+                    SELECT
+                        #{item.successNum}          AS success_num,
+                        #{item.failNum}             AS fail_num,
+                        #{item.failReason}          AS fail_reason,
+                        #{item.stopNum}             AS stop_num,
+                        #{item.stopReason}          AS stop_reason,
+                        #{item.cancelNum}           AS cancel_num,
+                        #{item.cancelReason}        AS cancel_reason,
+                        #{item.systemTaskType}      AS system_task_type,
+                        #{item.businessId}          AS business_id,
+                        #{item.triggerAt}           AS trigger_at
+                </foreach>
+            ) AS tt
+        WHERE rt.system_task_type = tt.system_task_type
+          AND rt.business_id = tt.business_id
+          AND rt.trigger_at = tt.trigger_at
+    </update>
+
+    <select id="selectJobLineList"
+            resultType="com.aizuda.snailjob.template.datasource.persistence.dataobject.DashboardLineResponseDO">
+        SELECT TO_CHAR(trigger_at, #{dateFormat})                               AS createDt,
+               COALESCE(SUM(success_num), 0)                                    AS success,
+               COALESCE(SUM(fail_num), 0)                                       AS failNum,
+               COALESCE(SUM(stop_num), 0)                                       AS stop,
+               COALESCE(SUM(cancel_num), 0)                                     AS cancel,
+               COALESCE(SUM(fail_num + stop_num + cancel_num), 0)               AS fail,
+               COALESCE(SUM(success_num + fail_num + stop_num + cancel_num), 0) AS total
+        FROM sj_job_summary
+        ${ew.customSqlSegment}
+        GROUP BY createDt
+    </select>
+
+    <select id="selectJobTask"
+            resultType="com.aizuda.snailjob.template.datasource.persistence.dataobject.DashboardCardResponseDO$JobTask">
+        SELECT COALESCE(SUM(success_num), 0)                                    AS successNum,
+               COALESCE(SUM(stop_num), 0)                                       AS stopNum,
+               COALESCE(SUM(cancel_num), 0)                                     AS cancelNum,
+               COALESCE(SUM(fail_num), 0)                                       AS failNum,
+               COALESCE(SUM(success_num + fail_num + stop_num + cancel_num), 0) AS totalNum
+        FROM sj_job_summary
+        ${ew.customSqlSegment}
+    </select>
+
+    <select id="selectDashboardRankList"
+            resultType="com.aizuda.snailjob.template.datasource.persistence.dataobject.DashboardRetryLineResponseDO$Rank">
+        SELECT
+            <if test="systemTaskType == 3">
+                CONCAT(group_name, '/', (SELECT job_name FROM sj_job WHERE id = business_id))           AS name,
+            </if>
+            <if test="systemTaskType == 4">
+                CONCAT(group_name, '/', (SELECT workflow_name FROM sj_workflow WHERE id = business_id)) AS name,
+            </if>
+            SUM(fail_num) AS total
+        FROM sj_job_summary
+        ${ew.customSqlSegment}
+        HAVING SUM(fail_num) > 0
+        ORDER BY total DESC LIMIT 10
+    </select>
+
+</mapper>

--- a/snail-job-datasource/snail-job-gauss-datasource/src/main/resources/gauss/mapper/JobTaskMapper.xml
+++ b/snail-job-datasource/snail-job-gauss-datasource/src/main/resources/gauss/mapper/JobTaskMapper.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.aizuda.snailjob.template.datasource.persistence.mapper.JobTaskMapper">
+
+    <insert id="insertBatch" parameterType="java.util.List">
+        INSERT INTO sj_job_task (namespace_id, group_name, job_id, task_batch_id, parent_id, task_status,
+                                 retry_count, mr_stage, leaf, task_name, client_info, wf_context, args_str,
+                                 result_message, args_type, ext_attrs, create_dt, update_dt)
+        VALUES
+        <foreach collection="list" item="item" separator=",">
+            (
+                #{item.namespaceId},
+                #{item.groupName},
+                #{item.jobId},
+                #{item.taskBatchId},
+                #{item.parentId},
+                #{item.taskStatus},
+                #{item.retryCount},
+                #{item.mrStage},
+                #{item.leaf},
+                #{item.taskName},
+                #{item.clientInfo},
+                #{item.wfContext},
+                #{item.argsStr},
+                #{item.resultMessage},
+                #{item.argsType},
+                #{item.extAttrs},
+                #{item.createDt},
+                #{item.updateDt}
+            )
+        </foreach>
+    </insert>
+
+</mapper>

--- a/snail-job-datasource/snail-job-gauss-datasource/src/main/resources/gauss/mapper/RetryDeadLetterMapper.xml
+++ b/snail-job-datasource/snail-job-gauss-datasource/src/main/resources/gauss/mapper/RetryDeadLetterMapper.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.aizuda.snailjob.template.datasource.persistence.mapper.RetryDeadLetterMapper">
+
+    <insert id="insertBatch" parameterType="java.util.List">
+        INSERT INTO sj_retry_dead_letter (namespace_id, group_name, group_id, scene_name, scene_id, idempotent_id, biz_no,
+                                          executor_name, args_str, ext_attrs, create_dt)
+        VALUES
+            <foreach collection="list" item="item" separator=",">
+                (
+                    #{item.namespaceId,jdbcType=VARCHAR},
+                    #{item.groupName,jdbcType=VARCHAR},
+                    #{item.groupId,jdbcType=BIGINT},
+                    #{item.sceneName,jdbcType=VARCHAR},
+                    #{item.sceneId,jdbcType=BIGINT},
+                    #{item.idempotentId,jdbcType=VARCHAR},
+                    #{item.bizNo,jdbcType=VARCHAR},
+                    #{item.executorName,jdbcType=VARCHAR},
+                    #{item.argsStr,jdbcType=VARCHAR},
+                    #{item.extAttrs,jdbcType=VARCHAR},
+                    #{item.createDt,jdbcType=TIMESTAMP}
+                )
+            </foreach>
+    </insert>
+
+</mapper>

--- a/snail-job-datasource/snail-job-gauss-datasource/src/main/resources/gauss/mapper/RetryMapper.xml
+++ b/snail-job-datasource/snail-job-gauss-datasource/src/main/resources/gauss/mapper/RetryMapper.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.aizuda.snailjob.template.datasource.persistence.mapper.RetryMapper">
+
+    <!-- 定义批量新增的 SQL 映射 -->
+    <insert id="insertBatch" parameterType="java.util.List">
+        INSERT INTO sj_retry (namespace_id, group_name, group_id, scene_name, scene_id,
+        idempotent_id, biz_no, executor_name, args_str, ext_attrs,
+        next_trigger_at, task_type, retry_status, create_dt, bucket_index, parent_id, deleted)
+        VALUES
+        <foreach collection="list" item="item" separator=",">
+            (
+            #{item.namespaceId}, #{item.groupName}, #{item.groupId}, #{item.sceneName}, #{item.sceneId}, #{item.idempotentId},
+            #{item.bizNo},#{item.executorName}, #{item.argsStr}, #{item.extAttrs}, #{item.nextTriggerAt}, #{item.taskType},
+            #{item.retryStatus}, #{item.createDt}, #{item.bucketIndex}, #{item.parentId}, #{item.deleted}
+            )
+        </foreach>
+    </insert>
+
+    <update id="updateBatchNextTriggerAtById" parameterType="java.util.List">
+        UPDATE sj_retry AS rt
+           SET next_trigger_at = tt.next_trigger_at,
+               update_dt = CURRENT_TIMESTAMP
+          FROM (
+                <foreach collection="list" item="item" index="index" separator="UNION ALL">
+                    SELECT
+                        #{item.id}              AS id,
+                        #{item.nextTriggerAt}   AS next_trigger_at
+                </foreach>
+                ) AS tt
+          WHERE rt.id = tt.id
+    </update>
+</mapper>

--- a/snail-job-datasource/snail-job-gauss-datasource/src/main/resources/gauss/mapper/RetrySummaryMapper.xml
+++ b/snail-job-datasource/snail-job-gauss-datasource/src/main/resources/gauss/mapper/RetrySummaryMapper.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.aizuda.snailjob.template.datasource.persistence.mapper.RetrySummaryMapper">
+
+    <insert id="insertBatch" parameterType="java.util.List">
+        INSERT INTO sj_retry_summary (namespace_id, group_name, scene_name, trigger_at,
+                                   running_num, finish_num, max_count_num, suspend_num)
+        VALUES
+            <foreach collection="list" item="item" separator=",">
+                (
+                    #{item.namespaceId},
+                    #{item.groupName},
+                    #{item.sceneName},
+                    #{item.triggerAt},
+                    #{item.runningNum},
+                    #{item.finishNum},
+                    #{item.maxCountNum},
+                    #{item.suspendNum}
+                )
+        </foreach>
+    </insert>
+
+    <update id="updateBatch" parameterType="java.util.List">
+        UPDATE sj_retry_summary AS rt
+           SET running_num = tt.running_num,
+               finish_num = tt.finish_num,
+               max_count_num = tt.max_count_num,
+               suspend_num = tt.suspend_num,
+               update_dt = CURRENT_TIMESTAMP
+          FROM (
+                <foreach collection="list" item="item" index="index" separator="UNION ALL">
+                    SELECT
+                        #{item.runningNum}  AS running_num,
+                        #{item.finishNum}   AS finish_num,
+                        #{item.maxCountNum} AS max_count_num,
+                        #{item.suspendNum}  AS suspend_num,
+                        #{item.triggerAt}   AS trigger_at,
+                        #{item.sceneName}   AS scene_name,
+                        #{item.namespaceId} AS namespace_id,
+                        #{item.groupName}   AS group_name
+                </foreach>
+            ) AS tt
+        WHERE rt.trigger_at = tt.trigger_at
+          AND rt.group_name = tt.group_name
+          AND rt.namespace_id = tt.namespace_id
+          AND rt.scene_name = tt.scene_name
+    </update>
+
+    <select id="selectRetryTask"
+            resultType="com.aizuda.snailjob.template.datasource.persistence.dataobject.DashboardCardResponseDO$RetryTask">
+        SELECT COALESCE(sum(running_num), 0)                                            AS runningNum,
+               COALESCE(sum(finish_num), 0)                                             AS finishNum,
+               COALESCE(sum(max_count_num), 0)                                          AS maxCountNum,
+               COALESCE(sum(suspend_num), 0)                                            AS suspendNum,
+               COALESCE(sum(running_num + finish_num + max_count_num + suspend_num), 0) AS totalNum
+        FROM sj_retry_summary
+        ${ew.customSqlSegment}
+    </select>
+
+    <select id="selectRetryTaskBarList"
+            resultType="com.aizuda.snailjob.template.datasource.persistence.dataobject.DashboardCardResponseDO$RetryTask">
+        SELECT trigger_at,
+               running_num,
+               finish_num,
+               max_count_num,
+               suspend_num
+          FROM sj_retry_summary
+        ${ew.customSqlSegment}
+        LIMIT 7
+    </select>
+
+    <select id="selectRetryLineList"
+            resultType="com.aizuda.snailjob.template.datasource.persistence.dataobject.DashboardLineResponseDO">
+        SELECT TO_CHAR(create_dt, #{dateFormat})                                        AS createDt,
+               COALESCE(SUM(finish_num), 0)                                             AS successNum,
+               COALESCE(SUM(running_num), 0)                                            AS runningNum,
+               COALESCE(SUM(max_count_num), 0)                                          AS maxCountNum,
+               COALESCE(SUM(suspend_num), 0)                                            AS suspendNum,
+               COALESCE(SUM(finish_num + running_num + max_count_num + suspend_num), 0) AS total
+          FROM sj_retry_summary
+        ${ew.customSqlSegment}
+         GROUP BY createDt
+    </select>
+
+    <select id="selectDashboardRankList"
+            resultType="com.aizuda.snailjob.template.datasource.persistence.dataobject.DashboardRetryLineResponseDO$Rank">
+        SELECT CONCAT(group_name, '/', scene_name)                          AS name,
+               SUM(running_num + finish_num + max_count_num + suspend_num)  AS total
+          FROM sj_retry_summary
+        ${ew.customSqlSegment}
+        HAVING SUM(running_num + finish_num + max_count_num + suspend_num) > 0
+         ORDER BY total DESC LIMIT 10
+    </select>
+
+</mapper>

--- a/snail-job-datasource/snail-job-gauss-datasource/src/main/resources/gauss/mapper/RetryTaskLogMessageMapper.xml
+++ b/snail-job-datasource/snail-job-gauss-datasource/src/main/resources/gauss/mapper/RetryTaskLogMessageMapper.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.aizuda.snailjob.template.datasource.persistence.mapper.RetryTaskLogMessageMapper">
+
+    <insert id="insertBatch" parameterType="java.util.List">
+        INSERT INTO sj_retry_task_log_message (namespace_id, group_name, retry_task_id, retry_id, log_num, message,
+                                            create_dt, real_time)
+        VALUES
+            <foreach collection="list" item="item" separator=",">
+                (
+                    #{item.namespaceId},
+                    #{item.groupName},
+                    #{item.retryTaskId},
+                    #{item.retryId},
+                    #{item.logNum},
+                    #{item.message},
+                    #{item.createDt},
+                    #{item.realTime}
+                )
+            </foreach>
+    </insert>
+
+    <update id="updateBatch" parameterType="java.util.List">
+        UPDATE sj_retry_task_log_message rt,
+                (
+                    <foreach collection="list" item="item" index="index" separator="UNION ALL">
+                        SELECT
+                            #{item.id} AS id,
+                            #{item.message} AS message,
+                            #{item.logNum} AS log_num
+                    </foreach>
+                ) tt
+           SET rt.message = tt.message,
+               rt.log_num = tt.log_num,
+               rt.update_dt = CURRENT_TIMESTAMP
+         WHERE rt.id = tt.id
+    </update>
+
+</mapper>

--- a/snail-job-datasource/snail-job-gauss-datasource/src/main/resources/gauss/mapper/ServerNodeMapper.xml
+++ b/snail-job-datasource/snail-job-gauss-datasource/src/main/resources/gauss/mapper/ServerNodeMapper.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.aizuda.snailjob.template.datasource.persistence.mapper.ServerNodeMapper">
+
+    <insert id="insertBatch" parameterType="java.util.List">
+        INSERT INTO sj_server_node (namespace_id, group_name, host_id, host_ip, host_port,
+                                 expire_at, node_type, ext_attrs, create_dt)
+        VALUES
+            <foreach collection="list" item="item" index="index" separator=",">
+                (
+                    #{item.namespaceId,jdbcType=VARCHAR},
+                    #{item.groupName,jdbcType=VARCHAR},
+                    #{item.hostId,jdbcType=VARCHAR},
+                    #{item.hostIp,jdbcType=VARCHAR},
+                    #{item.hostPort,jdbcType=INTEGER},
+                    #{item.expireAt,jdbcType=TIMESTAMP},
+                    #{item.nodeType,jdbcType=TINYINT},
+                    #{item.extAttrs,jdbcType=VARCHAR},
+                    #{item.createDt,jdbcType=TIMESTAMP}
+                )
+            </foreach>
+    </insert>
+
+    <update id="updateBatchExpireAt" parameterType="java.util.List">
+        UPDATE sj_server_node AS rt
+           SET expire_at = tt.expire_at,
+               update_dt = CURRENT_TIMESTAMP
+          FROM (
+                <foreach collection="list" item="item" index="index" separator="UNION ALL">
+                    SELECT
+                        #{item.hostId}      AS host_id,
+                        #{item.hostIp}      AS host_ip,
+                        #{item.expireAt}    AS expire_at
+                </foreach>
+            ) AS tt
+        WHERE rt.host_id = tt.host_id
+          AND rt.host_ip = tt.host_ip
+    </update>
+
+</mapper>

--- a/snail-job-datasource/snail-job-gauss-datasource/src/main/resources/gauss/mapper/WorkflowMapper.xml
+++ b/snail-job-datasource/snail-job-gauss-datasource/src/main/resources/gauss/mapper/WorkflowMapper.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.aizuda.snailjob.template.datasource.persistence.mapper.WorkflowMapper">
+
+    <update id="updateBatchNextTriggerAtById" parameterType="java.util.List">
+        UPDATE sj_workflow AS rt
+           SET next_trigger_at = tt.next_trigger_at,
+               update_dt = CURRENT_TIMESTAMP
+         FROM (
+                <foreach collection="list" item="item" index="index" separator="UNION ALL">
+                    SELECT
+                        #{item.id}              AS id,
+                        #{item.nextTriggerAt}   AS next_trigger_at
+                </foreach>
+            ) AS tt
+         WHERE rt.id = tt.id
+    </update>
+
+</mapper>

--- a/snail-job-server/snail-job-server-common/src/main/java/com/aizuda/snailjob/server/common/enums/DashboardLineEnum.java
+++ b/snail-job-server/snail-job-server-common/src/main/java/com/aizuda/snailjob/server/common/enums/DashboardLineEnum.java
@@ -36,16 +36,7 @@ public enum DashboardLineEnum {
     public static String dateFormat(String unit) {
         DashboardLineEnum mode = modeOf(unit);
 
-        if (DbUtils.getDbType().equals(DbTypeEnum.MYSQL)) {
-            switch (mode) {
-                case YEAR:
-                    return "%Y-%m";
-                case DAY:
-                    return "%H";
-                default:
-                    return "%Y-%m-%d";
-            }
-        } else if (DbUtils.getDbType().equals(DbTypeEnum.MARIADB)) {
+        if (DbUtils.getDbType().mysqlSameType()) {
             switch (mode) {
                 case YEAR:
                     return "%Y-%m";

--- a/snail-job-server/snail-job-server-common/src/main/java/com/aizuda/snailjob/server/common/lock/persistence/JdbcLockProvider.java
+++ b/snail-job-server/snail-job-server-common/src/main/java/com/aizuda/snailjob/server/common/lock/persistence/JdbcLockProvider.java
@@ -27,6 +27,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * 基于DB实现的分布式锁
@@ -40,21 +41,12 @@ import java.util.List;
 @RequiredArgsConstructor
 public class JdbcLockProvider implements LockStorage, Lifecycle {
 
-    protected static final List<String> ALLOW_DB = Arrays.asList(
-            DbTypeEnum.MYSQL.getDb(),
-            DbTypeEnum.MARIADB.getDb(),
-            DbTypeEnum.POSTGRES.getDb(),
-            DbTypeEnum.ORACLE.getDb(),
-            DbTypeEnum.SQLSERVER.getDb(),
-            DbTypeEnum.DM.getDb(),
-            DbTypeEnum.KINGBASE.getDb());
-
     private final DistributedLockMapper distributedLockMapper;
     private final PlatformTransactionManager platformTransactionManager;
 
     @Override
     public boolean supports(final String storageMedium) {
-        return ALLOW_DB.contains(storageMedium);
+        return Objects.requireNonNull(DbTypeEnum.findByName(storageMedium)).isAllowDb();
     }
 
     @Override

--- a/snail-job-server/snail-job-server-common/src/main/java/com/aizuda/snailjob/server/common/lock/persistence/LockStorageFactory.java
+++ b/snail-job-server/snail-job-server-common/src/main/java/com/aizuda/snailjob/server/common/lock/persistence/LockStorageFactory.java
@@ -23,7 +23,7 @@ public final class LockStorageFactory {
     public static LockStorage getLockStorage() {
         DbTypeEnum db = DbUtils.getDbType();
         return LOCK_STORAGES.stream()
-                .filter(lockProvider -> lockProvider.supports(db.getDb()))
+                .filter(lockProvider -> lockProvider.supports(db.getName()))
                 .findFirst().orElseThrow(() -> new SnailJobServerException("Suitable lock handler not found"));
     }
 

--- a/snail-job-server/snail-job-server-job-task/src/main/java/com/aizuda/snailjob/server/job/task/support/generator/task/AbstractJobTaskGenerator.java
+++ b/snail-job-server/snail-job-server-job-task/src/main/java/com/aizuda/snailjob/server/job/task/support/generator/task/AbstractJobTaskGenerator.java
@@ -40,8 +40,7 @@ public abstract class AbstractJobTaskGenerator implements JobTaskGenerator, Init
     protected void batchSaveJobTasks(List<JobTask> jobTasks) {
         // ORACLE 批次插入不能直接返回id，因此此处特殊处理
         // 后期版本会对snail-job-datasource进行重构，在考虑此处的兼容逻辑
-        if (Sets.newHashSet(DbTypeEnum.ORACLE.getDb(), DbTypeEnum.SQLSERVER.getDb())
-                .contains(DbUtils.getDbType().getDb())) {
+        if (List.of(DbTypeEnum.ORACLE, DbTypeEnum.SQLSERVER).contains(DbUtils.getDbType()) || DbUtils.getDbType().oracleSameType()) {
             // sqlserver oracle 不支持返回批量id,故暂时先这样处理
             for (JobTask jobTask : jobTasks) {
                 Assert.isTrue(1 == jobTaskMapper.insert(jobTask), () -> new SnailJobServerException("Adding new task instance failed"));

--- a/snail-job-server/snail-job-server-starter/pom.xml
+++ b/snail-job-server/snail-job-server-starter/pom.xml
@@ -113,6 +113,8 @@
                 <configuration>
                     <mainClass>com.aizuda.snailjob.server.SnailJobServerApplication</mainClass>
                     <classifier>exec</classifier>
+                    <!-- 使用 PropertiesLauncher 启动器，镜像中可以使用-Dloader.path=/drivers/path/ 需要额外加载的驱动jar -->
+                    <layout>ZIP</layout>
                 </configuration>
                 <executions>
                     <execution>

--- a/snail-job-server/snail-job-server-starter/src/main/java/com/aizuda/snailjob/server/SnailJobServerApplication.java
+++ b/snail-job-server/snail-job-server-starter/src/main/java/com/aizuda/snailjob/server/SnailJobServerApplication.java
@@ -14,12 +14,9 @@
  */
 package com.aizuda.snailjob.server;
 
+import com.aizuda.snailjob.common.core.model.LongToStringModule;
 import com.aizuda.snailjob.server.common.rpc.server.grpc.GrpcServer;
 import com.aizuda.snailjob.server.common.rpc.server.netty.NettyHttpServer;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.module.SimpleModule;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.SpringApplication;
@@ -28,7 +25,6 @@ import org.springframework.boot.web.servlet.server.ServletWebServerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
-import java.io.IOException;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
@@ -67,20 +63,7 @@ public class SnailJobServerApplication {
     }
 
     @Bean
-    public SimpleModule longToStringModule() {
-        SimpleModule module = new SimpleModule();
-        module.addSerializer(Long.class, new JsonSerializer<>() {
-            @Override
-            public void serialize(Long value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
-                gen.writeString(value.toString());
-            }
-        });
-        module.addSerializer(Long.TYPE, new JsonSerializer<>() {
-            @Override
-            public void serialize(Long value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
-                gen.writeString(value.toString());
-            }
-        });
-        return module;
+    public LongToStringModule longToStringModule() {
+        return new LongToStringModule();
     }
 }

--- a/snail-job-server/snail-job-server-starter/src/main/java/com/aizuda/snailjob/server/SnailJobServerApplication.java
+++ b/snail-job-server/snail-job-server-starter/src/main/java/com/aizuda/snailjob/server/SnailJobServerApplication.java
@@ -16,6 +16,10 @@ package com.aizuda.snailjob.server;
 
 import com.aizuda.snailjob.server.common.rpc.server.grpc.GrpcServer;
 import com.aizuda.snailjob.server.common.rpc.server.netty.NettyHttpServer;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.SpringApplication;
@@ -24,6 +28,7 @@ import org.springframework.boot.web.servlet.server.ServletWebServerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
+import java.io.IOException;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
@@ -59,5 +64,23 @@ public class SnailJobServerApplication {
                 SpringApplication.exit(SpringApplication.run(SnailJobServerApplication.class));
             }
         };
+    }
+
+    @Bean
+    public SimpleModule longToStringModule() {
+        SimpleModule module = new SimpleModule();
+        module.addSerializer(Long.class, new JsonSerializer<>() {
+            @Override
+            public void serialize(Long value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+                gen.writeString(value.toString());
+            }
+        });
+        module.addSerializer(Long.TYPE, new JsonSerializer<>() {
+            @Override
+            public void serialize(Long value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+                gen.writeString(value.toString());
+            }
+        });
+        return module;
     }
 }

--- a/snail-job-server/snail-job-server-web/pom.xml
+++ b/snail-job-server/snail-job-server-web/pom.xml
@@ -93,6 +93,10 @@
         </dependency>
         <dependency>
             <groupId>com.aizuda</groupId>
+            <artifactId>snail-job-gauss-datasource</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.aizuda</groupId>
             <artifactId>snail-job-server-retry-task</artifactId>
         </dependency>
         <dependency>

--- a/snail-job-server/snail-job-server-web/src/main/java/com/aizuda/snailjob/server/web/service/impl/GroupConfigServiceImpl.java
+++ b/snail-job-server/snail-job-server-web/src/main/java/com/aizuda/snailjob/server/web/service/impl/GroupConfigServiceImpl.java
@@ -282,7 +282,7 @@ public class GroupConfigServiceImpl implements GroupConfigService {
             String tableNamePattern = "sj_retry_task_%";
             DbTypeEnum dbType = DbUtils.getDbType();
             // Oracle, DM 查询表名大写
-            if (DbTypeEnum.ORACLE.getDb().equals(dbType.getDb()) || DbTypeEnum.DM.getDb().equals(dbType.getDb())) {
+            if (DbTypeEnum.ORACLE.getName().equals(dbType.getName()) || DbTypeEnum.DM.getName().equals(dbType.getName())) {
                 tableNamePattern = tableNamePattern.toUpperCase();
             }
 


### PR DESCRIPTION
- 更新 MyBatis-Plus 版本至 3.5.12
- 移除 ALLOW_DB 列表，改为在 DbTypeEnum 中定义允许的数据库类型
- 优化数据库类型的自动识别逻辑，增加对更多数据库类型识别的支持
- 增加未找到识别的数据库mapper配置时，使用兼容的语法作为兜底策略
- 高斯数据库不支持 RETURNING 语法，使用雪花 ID（向前端传输ID时，由于雪花ID长度问题会导致精度丢失，所以向页面返回ID时将Long转为String返回可以有效解决该问题）
- 增加高斯数据库初始化SQL
- 添加 PropertiesLauncher 启动配置（镜像中可以使用 -Dloader.path=/drivers/path/ 需要额外加载的驱动jar）